### PR TITLE
toggle waiting tag

### DIFF
--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -646,6 +646,18 @@ namespace Astroid {
           return true;
         });
 
+    keys->register_key ("w", "thread_index.waiting",
+        "Toggle 'waiting' tag on thread",
+        [&] (Key) {
+          auto thread = get_current_thread ();
+          if (thread) {
+            Db db (Db::DbMode::DATABASE_READ_WRITE);
+            main_window->actions.doit (&db, refptr<Action>(new ToggleAction(thread, "waiting")));
+          }
+
+          return true;
+        });
+
     keys->register_key (Key (GDK_KEY_asterisk), "thread_index.flag",
         "Toggle 'flagged' tag on thread",
         [&] (Key) {


### PR DESCRIPTION
Tagging emails where you are waiting for an answer is useful.

This adds the "w" keybinding for toggling the "waiting" tag.