### PR TITLE
Allow sent tags to be configured

### DIFF
--- a/src/db.hh
+++ b/src/db.hh
@@ -103,7 +103,8 @@ namespace Astroid {
       void load_tags ();
       void test_query ();
 
-      vector<ustring> sent_tags = { "sent" };
+      /* FIXME: add astroid.notmuch.sent_tags in config */
+      vector<ustring> sent_tags = { "sent,inbox" }; 
       vector<ustring> draft_tags = { "draft" };
       void add_sent_message (ustring);
       void add_draft_message (ustring);


### PR DESCRIPTION
I prefer to add an inbox tag to messages I send. That way I can see when I haven't got an answer, etc. This adds an inbox tag to the sent tag of sent emails. Ideally of course, this shouldn't be hardcoded but, like "excluded_tags" in the config file.