### PR TITLE
Fix #15

### DIFF
--- a/src/command_bar.cc
+++ b/src/command_bar.cc
@@ -374,8 +374,10 @@ namespace Astroid {
                                 // not the first
       newt += completion;
 
-      // add remainder of text field
-      newt += t.substr (pos+key.size() + ((pos > 0) ? 1 : 0), t.size());
+      // add remainder of text field only if we are not at the end of the line
+      if (pos + key.size() < t.size()) {
+        newt += t.substr (pos+key.size() + ((pos > 0) ? 1 : 0), t.size());
+      }
 
       entry->set_text (newt);
       entry->set_position (pos + completion.size()+((pos > 0) ? 1 : 0));


### PR DESCRIPTION
Do not try to substr the tail if we complete at the end of the
command bar. This will prevent overflows.