### PR TITLE
remove "using namespace" from headers.

### DIFF
--- a/src/account_manager.hh
+++ b/src/account_manager.hh
@@ -6,8 +6,6 @@
 # include "proto.hh"
 # include "utils/address.hh"
 
-using namespace std;
-
 namespace Astroid {
   class Account {
     public:
@@ -21,7 +19,7 @@ namespace Astroid {
 
       bool save_sent;
       ustring save_sent_to;
-      vector<ustring> additional_sent_tags;
+      std::vector<ustring> additional_sent_tags;
       ustring save_drafts_to;
 
       ustring full_address ();
@@ -34,7 +32,7 @@ namespace Astroid {
       AccountManager ();
       ~AccountManager ();
 
-      vector<Account> accounts;
+      std::vector<Account> accounts;
       int default_account;
       Account * get_account_for_address (ustring);
       Account * get_account_for_address (Address);

--- a/src/actions/action.hh
+++ b/src/actions/action.hh
@@ -1,19 +1,17 @@
 # pragma once
 
 # include <glibmm.h>
+# include <vector>
 
-# include "astroid.hh"
 # include "proto.hh"
-
-using namespace std;
 
 namespace Astroid {
   class Action : public Glib::Object {
     public:
       Action (refptr<NotmuchThread>);
-      Action (vector<refptr<NotmuchThread>>);
+      Action (std::vector<refptr<NotmuchThread>>);
 
-      vector<refptr<NotmuchThread>> threads;
+      std::vector<refptr<NotmuchThread>> threads;
 
       virtual bool doit (Db *) = 0;
       virtual bool undo (Db *) = 0;

--- a/src/actions/action_manager.hh
+++ b/src/actions/action_manager.hh
@@ -5,17 +5,14 @@
 # include <sigc++/sigc++.h>
 # include <glibmm/threads.h>
 
-# include "astroid.hh"
 # include "proto.hh"
-
-using namespace std;
 
 namespace Astroid {
   class ActionManager {
     public:
       ActionManager ();
 
-      vector<refptr<Action>> actions;
+      std::vector<refptr<Action>> actions;
 
       bool doit (Db *, refptr<Action>);
       bool undo ();

--- a/src/actions/tag_action.hh
+++ b/src/actions/tag_action.hh
@@ -1,6 +1,6 @@
 # pragma once
 
-using namespace std;
+# include <vector>
 
 # include "proto.hh"
 # include "action.hh"
@@ -12,18 +12,18 @@ namespace Astroid {
 
       TagAction (
           refptr<NotmuchThread>,
-          const vector<ustring>,
-          const vector<ustring>);
+          const std::vector<ustring>,
+          const std::vector<ustring>);
 
-      TagAction (vector<refptr<NotmuchThread>>);
+      TagAction (std::vector<refptr<NotmuchThread>>);
 
       TagAction (
-          vector<refptr<NotmuchThread>>,
-          const vector<ustring>,
-          const vector<ustring>);
+          std::vector<refptr<NotmuchThread>>,
+          const std::vector<ustring>,
+          const std::vector<ustring>);
 
-      vector<ustring> add;
-      vector<ustring> remove;
+      std::vector<ustring> add;
+      std::vector<ustring> remove;
 
       virtual bool doit (Db *) override;
       virtual bool undo (Db *) override;

--- a/src/actions/toggle_action.hh
+++ b/src/actions/toggle_action.hh
@@ -1,6 +1,6 @@
 # pragma once
 
-using namespace std;
+# include <vector>
 
 # include "proto.hh"
 # include "action.hh"
@@ -9,7 +9,7 @@ namespace Astroid {
   class ToggleAction : public TagAction {
     public:
       ToggleAction (refptr<NotmuchThread>, ustring);
-      ToggleAction (vector<refptr<NotmuchThread>>, ustring);
+      ToggleAction (std::vector<refptr<NotmuchThread>>, ustring);
       ustring toggle_tag;
 
       /* for toggleaction undo == doit, which works with
@@ -20,13 +20,13 @@ namespace Astroid {
   class SpamAction : public ToggleAction {
     public:
       SpamAction (refptr<NotmuchThread>);
-      SpamAction (vector<refptr<NotmuchThread>>);
+      SpamAction (std::vector<refptr<NotmuchThread>>);
   };
 
   class MuteAction : public ToggleAction {
     public:
       MuteAction (refptr<NotmuchThread>);
-      MuteAction (vector<refptr<NotmuchThread>>);
+      MuteAction (std::vector<refptr<NotmuchThread>>);
   };
 
 }

--- a/src/astroid.hh
+++ b/src/astroid.hh
@@ -1,14 +1,11 @@
 # pragma once
 
 # include <vector>
-# include <memory>
 
 # include <gtkmm.h>
 # include <glibmm.h>
 
 # include "proto.hh"
-
-using namespace std;
 
 namespace Astroid {
   class Astroid {

--- a/src/chunk.cc
+++ b/src/chunk.cc
@@ -18,18 +18,17 @@
 # include "config.hh"
 # include "crypto.hh"
 
-using namespace boost::filesystem;
-
 namespace Astroid {
 
-  atomic<uint> Chunk::nextid (0);
+  std::atomic<uint> Chunk::nextid (0);
 
   Chunk::Chunk (GMimeObject * mp) : mime_object (mp) {
+    using std::endl;
     id = nextid++;
 
     if (mp == NULL) {
       log << error << "chunk: got NULL mime_object." << endl;
-      throw logic_error ("chunk: got NULL mime_object");
+      throw std::logic_error ("chunk: got NULL mime_object");
     }
 
     content_type = g_mime_object_get_content_type (mime_object);
@@ -43,7 +42,7 @@ namespace Astroid {
     if (GMIME_IS_PART (mime_object)) {
       // has no sub-parts
 
-      string disposition = g_mime_object_get_disposition(mime_object) ? : string();
+      std::string disposition = g_mime_object_get_disposition(mime_object) ? : std::string();
       viewable = !(disposition == "attachment");
 
       const char * cid = g_mime_part_get_content_id ((GMimePart *) mime_object);
@@ -189,6 +188,7 @@ namespace Astroid {
   }
 
   ustring Chunk::viewable_text (bool html = true) {
+    using std::endl;
 
     GMimeStream * content_stream = NULL;
 
@@ -232,7 +232,7 @@ namespace Astroid {
         if (charset)
         {
           log << debug << "charset: " << charset << endl;
-          if (string(charset) == "utf-8") {
+          if (std::string(charset) == "utf-8") {
             charset = "UTF-8";
           }
 
@@ -289,7 +289,7 @@ namespace Astroid {
         if (charset)
         {
           log << debug << "charset: " << charset << endl;
-          if (string(charset) == "utf-8") {
+          if (std::string(charset) == "utf-8") {
             charset = "UTF-8";
           }
 
@@ -312,7 +312,7 @@ namespace Astroid {
       char buffer[4097];
       ssize_t prevn = 1;
       ssize_t n;
-      stringstream sstr;
+      std::stringstream sstr;
 
       while ((n = g_mime_stream_read (content_stream, buffer, 4096), n) >= 0)
       {
@@ -378,7 +378,7 @@ namespace Astroid {
     refptr<Glib::ByteArray> cnt = contents ();
     size_t sz = cnt->size ();
 
-    log << info << "chunk: file size: " << sz << " (time used to calculate: " << ( (clock () - t0) * 1000.0 / CLOCKS_PER_SEC ) << " ms.)" << endl;
+    log << info << "chunk: file size: " << sz << " (time used to calculate: " << ( (clock () - t0) * 1000.0 / CLOCKS_PER_SEC ) << " ms.)" << std::endl;
 
     return sz;
   }
@@ -412,13 +412,15 @@ namespace Astroid {
 
     g_object_unref (mem);
 
-    log << info << "chunk: contents: loaded " << data->size () << " bytes in " << ( (clock () - t0) * 1000.0 / CLOCKS_PER_SEC ) << " ms." << endl;
+    log << info << "chunk: contents: loaded " << data->size () << " bytes in " << ( (clock () - t0) * 1000.0 / CLOCKS_PER_SEC ) << " ms." << std::endl;
 
     return data;
   }
 
-  bool Chunk::save_to (string filename, bool overwrite) {
+  bool Chunk::save_to (std::string filename, bool overwrite) {
     /* saves chunk to file name, if filename is dir, own name */
+    using std::endl;
+    using bfs::path;
 
     path to (filename.c_str());
 
@@ -494,14 +496,15 @@ namespace Astroid {
   }
 
   void Chunk::open () {
-    log << info << "chunk: " << get_filename () << ", opening.." << endl;
+    using bfs::path;
+    log << info << "chunk: " << get_filename () << ", opening.." << std::endl;
 
     path tf = astroid->config->cache_dir;
 
     ustring tmp_fname = ustring::compose("%1-%2", UstringUtils::random_alphanumeric (10), Utils::safe_fname(get_filename ()));
     tf /= path (tmp_fname.c_str());
 
-    log << debug << "chunk: saving to tmp path: " << tf.c_str() << endl;
+    log << debug << "chunk: saving to tmp path: " << tf.c_str() << std::endl;
     save_to (tf.c_str());
 
     ustring tf_p (tf.c_str());
@@ -513,12 +516,13 @@ namespace Astroid {
   }
 
   void Chunk::do_open (ustring tf) {
-    ustring external_cmd = astroid->config->config.get<string> ("attachment.external_open_cmd");
+    using std::endl;
+    ustring external_cmd = astroid->config->config.get<std::string> ("attachment.external_open_cmd");
 
-    vector<string> args = { external_cmd.c_str(), tf.c_str () };
+    std::vector<std::string> args = { external_cmd.c_str(), tf.c_str () };
     log << debug << "chunk: spawning: " << args[0] << ", " << args[1] << endl;
-    string stdout;
-    string stderr;
+    std::string stdout;
+    std::string stderr;
     int    exitcode;
     try {
       Glib::spawn_sync ("",
@@ -581,6 +585,7 @@ namespace Astroid {
   }
 
   void Chunk::save () {
+    using std::endl;
     log << info << "chunk: " << get_filename () << ", saving.." << endl;
     Gtk::FileChooserDialog dialog ("Save attachment to folder..",
         Gtk::FILE_CHOOSER_ACTION_SAVE);
@@ -596,7 +601,7 @@ namespace Astroid {
     switch (result) {
       case (Gtk::RESPONSE_OK):
         {
-          string fname = dialog.get_filename ();
+          std::string fname = dialog.get_filename ();
           log << info << "chunk: saving attachment to: " << fname << endl;
 
           /* the dialog asks whether to overwrite or not */
@@ -614,8 +619,8 @@ namespace Astroid {
 
   refptr<Message> Chunk::get_mime_message () {
     if (!mime_message) {
-      log << error << "chunk: this is not a mime message." << endl;
-      throw runtime_error ("chunk: not a mime message");
+      log << error << "chunk: this is not a mime message." << std::endl;
+      throw std::runtime_error ("chunk: not a mime message");
     }
 
     refptr<Message> m = refptr<Message> ( new Message (GMIME_MESSAGE(mime_object)) );

--- a/src/chunk.hh
+++ b/src/chunk.hh
@@ -3,18 +3,17 @@
 # include <vector>
 # include <map>
 # include <atomic>
+# include <string>
 
 # include <gmime/gmime.h>
 
 # include "astroid.hh"
 # include "proto.hh"
 
-using namespace std;
-
 namespace Astroid {
   class Chunk : public Glib::Object {
     private:
-      static atomic<uint> nextid;
+      static std::atomic<uint> nextid;
 
     public:
       Chunk (GMimeObject *);
@@ -31,8 +30,8 @@ namespace Astroid {
 
       ustring viewable_text (bool);
 
-      vector<refptr<Chunk>> kids;
-      vector<refptr<Chunk>> siblings;
+      std::vector<refptr<Chunk>> kids;
+      std::vector<refptr<Chunk>> siblings;
       refptr<Chunk> get_by_id (int, bool check_siblings = true);
 
       bool any_kids_viewable ();
@@ -48,7 +47,7 @@ namespace Astroid {
 
       refptr<Message> get_mime_message ();
 
-      map<ustring, GMimeContentType *> viewable_types = {
+      std::map<ustring, GMimeContentType *> viewable_types = {
         { "plain", g_mime_content_type_new ("text", "plain") },
         { "html" , g_mime_content_type_new ("text", "html") }
       };
@@ -60,7 +59,7 @@ namespace Astroid {
       size_t  get_file_size ();
       refptr<Glib::ByteArray> contents ();
 
-      bool save_to (string filename, bool overwrite = false);
+      bool save_to (std::string filename, bool overwrite = false);
       void open ();
       void save ();
 

--- a/src/command_bar.cc
+++ b/src/command_bar.cc
@@ -92,7 +92,7 @@ namespace Astroid {
     callback = NULL;
   }
 
-  void CommandBar::enable_command (CommandMode m, ustring cmd, function<void(ustring)> f) {
+  void CommandBar::enable_command (CommandMode m, ustring cmd, std::function<void(ustring)> f) {
     mode = m;
 
     reset_bar ();
@@ -217,12 +217,12 @@ namespace Astroid {
    ********************/
   bool CommandBar::GenericCompletion::match (const ustring&, const Gtk::TreeModel::const_iterator&) {
     // do not call directly
-    throw bad_function_call ();
+    throw std::bad_function_call ();
   }
 
   bool CommandBar::GenericCompletion::on_match_selected(const Gtk::TreeModel::iterator&) {
     // do not call directly
-    throw bad_function_call ();
+    throw std::bad_function_call ();
   }
 
   /* get the next match in the list and use it to complete */

--- a/src/command_bar.hh
+++ b/src/command_bar.hh
@@ -17,8 +17,6 @@
 # include "astroid.hh"
 # include "proto.hh"
 
-using namespace std;
-
 namespace Astroid {
   class CommandBar : public Gtk::SearchBar {
     public:
@@ -40,9 +38,9 @@ namespace Astroid {
       void set_main_window (MainWindow *);
 
       void on_entry_activated ();
-      function<void(ustring)> callback;
+      std::function<void(ustring)> callback;
 
-      void enable_command (CommandMode, ustring, function<void(ustring)>);
+      void enable_command (CommandMode, ustring, std::function<void(ustring)>);
       void disable_command ();
 
       //void handle_command (ustring);
@@ -75,15 +73,15 @@ namespace Astroid {
       /********************
        * Tag editing
        ********************/
-      vector<ustring> existing_tags; // a sorted list of existing tags
+      std::vector<ustring> existing_tags; // a sorted list of existing tags
       void start_tagging (ustring);
 
       class TagCompletion : public GenericCompletion {
         public:
           TagCompletion ();
 
-          void load_tags (vector<ustring>);
-          vector<ustring> tags; // must be sorted
+          void load_tags (std::vector<ustring>);
+          std::vector<ustring> tags; // must be sorted
 
           // tree model columns, for the EntryCompletion's filter model
           class ModelColumns : public Gtk::TreeModel::ColumnRecord
@@ -117,8 +115,8 @@ namespace Astroid {
         public:
           SearchCompletion ();
 
-          void load_tags (vector<ustring>);
-          vector<ustring> tags; // must be sorted
+          void load_tags (std::vector<ustring>);
+          std::vector<ustring> tags; // must be sorted
 
           // tree model columns, for the EntryCompletion's filter model
           class ModelColumns : public Gtk::TreeModel::ColumnRecord

--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -16,7 +16,7 @@
 # include "chunk.hh"
 
 using namespace std;
-using namespace boost::filesystem;
+namespace bfs = boost::filesystem;
 
 namespace Astroid {
   ComposeMessage::ComposeMessage () {
@@ -248,6 +248,7 @@ namespace Astroid {
           log << warn << "cm: message sent successfully!" << endl;
 
         if (account->save_sent) {
+          using bfs::path;
           path save_to = path(account->save_sent_to) / path(id + ":2,");
           if (output)
             log << info << "cm: saving message to: " << save_to << endl;
@@ -324,7 +325,7 @@ namespace Astroid {
     log << debug << "cm: wrote file: " << fname << endl;
   }
 
-  ComposeMessage::Attachment::Attachment (path p) {
+  ComposeMessage::Attachment::Attachment (bfs::path p) {
     log << debug << "cm: at: construct from file." << endl;
     fname   = p;
     on_disk = true;
@@ -370,7 +371,7 @@ namespace Astroid {
 
     const char * ct = g_mime_content_type_to_string (c->content_type);
     if (ct != NULL) {
-      content_type = string (ct);
+      content_type = std::string (ct);
     } else {
       content_type = "application/octet-stream";
     }

--- a/src/compose_message.hh
+++ b/src/compose_message.hh
@@ -2,7 +2,9 @@
 
 # include <iostream>
 # include <vector>
+# include <string>
 # include <functional>
+# include <memory>
 # include <boost/filesystem.hpp>
 
 # include <gmime/gmime.h>
@@ -10,8 +12,7 @@
 # include "astroid.hh"
 # include "proto.hh"
 
-using namespace std;
-using namespace boost::filesystem;
+namespace bfs = boost::filesystem;
 
 namespace Astroid {
 
@@ -38,7 +39,7 @@ namespace Astroid {
 
       ustring to, cc, bcc, id, subject, references, inreplyto;
 
-      ostringstream body;
+      std::ostringstream body;
 
       void set_from (Account *);
       void set_to   (ustring);
@@ -51,22 +52,22 @@ namespace Astroid {
 
       struct Attachment {
         public:
-          Attachment (path);
+          Attachment (bfs::path);
           Attachment (refptr<Chunk>);
           Attachment (refptr<Message>);
           ~Attachment ();
           ustring name;
-          path    fname;
+          bfs::path    fname;
           bool    on_disk;
           bool    is_mime_message = false;
           bool    valid;
 
           refptr<Glib::ByteArray> contents;
-          string                  content_type;
+          std::string             content_type;
       };
 
-      void add_attachment (shared_ptr<Attachment>);
-      vector<shared_ptr<Attachment>> attachments;
+      void add_attachment (std::shared_ptr<Attachment>);
+      std::vector<std::shared_ptr<Attachment>> attachments;
 
       void load_message (ustring, ustring); // load draft or message as new
 

--- a/src/config.hh
+++ b/src/config.hh
@@ -8,8 +8,7 @@
 # include <boost/property_tree/ptree.hpp>
 # include <boost/property_tree/json_parser.hpp>
 
-using namespace std;
-using namespace boost::filesystem;
+namespace bfs = boost::filesystem;
 using boost::property_tree::ptree;
 
 namespace Astroid {
@@ -27,13 +26,13 @@ namespace Astroid {
 
       bool test;
 
-      path home;
-      path config_dir;
-      path data_dir;
-      path cache_dir;
-      path runtime_dir;
+      bfs::path home;
+      bfs::path config_dir;
+      bfs::path data_dir;
+      bfs::path cache_dir;
+      bfs::path runtime_dir;
 
-      path config_file;
+      bfs::path config_file;
 
       void load_config (bool initial = false);
       void load_dirs ();
@@ -59,7 +58,7 @@ namespace Astroid {
 
       void traverse(
           const boost::property_tree::ptree &parent,
-          function<void(const ptree &,
+          std::function<void(const ptree &,
             const ptree::path_type &,
             const ptree&)> method);
 

--- a/src/contacts.hh
+++ b/src/contacts.hh
@@ -1,13 +1,10 @@
 # pragma once
 
-# include <iostream>
 # include <vector>
 
 # include "astroid.hh"
 # include "proto.hh"
 # include "config.hh"
-
-using namespace std;
 
 namespace Astroid {
   class Contacts {
@@ -26,8 +23,8 @@ namespace Astroid {
 
       void add_contact (ustring);
 
-      vector<ustring> contacts;
-      vector<ustring>::iterator search_external (ustring);
+      std::vector<ustring> contacts;
+      std::vector<ustring>::iterator search_external (ustring);
 
       class ContactCompletion : public Gtk::EntryCompletion {
         public:

--- a/src/crypto.cc
+++ b/src/crypto.cc
@@ -1,6 +1,8 @@
 # include <glib.h>
 # include <gmime/gmime.h>
 
+# include <string>
+
 # include <boost/algorithm/string.hpp>
 
 # include "astroid.hh"
@@ -12,8 +14,9 @@
 
 namespace Astroid {
   Crypto::Crypto (ustring _protocol) {
+    using std::endl;
     ptree config = astroid->config->config.get_child ("crypto");
-    gpgpath = ustring (config.get<string> ("gpg.path"));
+    gpgpath = ustring (config.get<std::string> ("gpg.path"));
 
     log << debug << "crypto: gpg: " << gpgpath << endl;
 
@@ -40,6 +43,7 @@ namespace Astroid {
   }
 
   GMimeObject * Crypto::decrypt_and_verify (GMimeObject * part) {
+    using std::endl;
     log << debug << "crypto: decrypting and verifiying.." << endl;
     decrypt_tried = true;
     verify_tried = true;
@@ -71,7 +75,7 @@ namespace Astroid {
   bool Crypto::create_gpg_context () {
     gpgctx = g_mime_gpg_context_new (NULL, gpgpath.length() ? gpgpath.c_str () : "gpg");
     if (! gpgctx) {
-      log << error << "crypto: failed to create gpg context." << endl;
+      log << error << "crypto: failed to create gpg context." << std::endl;
       return false;
     }
 
@@ -93,9 +97,9 @@ namespace Astroid {
     unsigned char digest[16];
     g_mime_filter_md5_get_digest (GMIME_FILTER_MD5(md5f), digest);
 
-    ostringstream os;
+    std::ostringstream os;
     for (int i = 0; i < 16; i++) {
-      os << hex << setfill('0') << setw(2) << ((int)digest[i]);
+      os << std::hex << std::setfill('0') << std::setw(2) << ((int)digest[i]);
     }
 
     g_object_unref (md5f);

--- a/src/crypto.hh
+++ b/src/crypto.hh
@@ -1,15 +1,9 @@
 # pragma once
 
-# include <vector>
-# include <map>
-# include <atomic>
-
 # include <gmime/gmime.h>
 
 # include "astroid.hh"
 # include "proto.hh"
-
-using namespace std;
 
 namespace Astroid {
   class Crypto {

--- a/src/db.hh
+++ b/src/db.hh
@@ -2,7 +2,7 @@
 
 # include <mutex>
 # include <atomic>
-# include <condition_variable>
+# include <functional>
 
 # include <vector>
 
@@ -14,8 +14,6 @@
 # include "astroid.hh"
 # include "config.hh"
 # include "proto.hh"
-
-using namespace std;
 
 namespace Astroid {
   /* the notmuch thread object should get by on the db only */
@@ -33,8 +31,8 @@ namespace Astroid {
       bool    attachment;
       bool    flagged;
       int     total_messages;
-      vector<ustring> authors;
-      vector<ustring> tags;
+      std::vector<ustring> authors;
+      std::vector<ustring> tags;
 
       bool has_tag (ustring);
 
@@ -48,11 +46,11 @@ namespace Astroid {
 
     private:
       int     check_total_messages (notmuch_thread_t *);
-      vector<ustring> get_authors (notmuch_thread_t *);
-      vector<ustring> get_tags (notmuch_thread_t *);
+      std::vector<ustring> get_authors (notmuch_thread_t *);
+      std::vector<ustring> get_tags (notmuch_thread_t *);
   };
 
-  class Db : public recursive_mutex {
+  class Db : public std::recursive_mutex {
     public:
       enum DbMode {
         DATABASE_READ_ONLY,
@@ -65,8 +63,8 @@ namespace Astroid {
       void reopen ();
       bool check_reopen (bool);
 
-      void on_thread  (ustring, function <void(notmuch_thread_t *)>);
-      void on_message (ustring, function <void(notmuch_message_t *)>);
+      void on_thread  (ustring, std::function <void(notmuch_thread_t *)>);
+      void on_message (ustring, std::function <void(notmuch_message_t *)>);
 
       bool thread_in_query (ustring, ustring);
 
@@ -83,13 +81,13 @@ namespace Astroid {
       };
 
       /* internal lock for open and close operations */
-      atomic<DbState> db_state;
+      std::atomic<DbState> db_state;
 
       bool open_db_write (bool);
       bool open_db_read_only ();
       void close_db ();
 
-      path path_db;
+      bfs::path path_db;
       const int db_write_open_timeout = 30; // seconds
       const int db_write_open_delay   = 1; // seconds
 
@@ -98,23 +96,23 @@ namespace Astroid {
 
       ptree config;
 
-      vector<ustring> tags;
+      std::vector<ustring> tags;
 
       void load_tags ();
       void test_query ();
 
-      vector<ustring> sent_tags = { "sent" };
-      vector<ustring> draft_tags = { "draft" };
-      vector<ustring> excluded_tags = { "muted", "spam", "deleted" };
+      std::vector<ustring> sent_tags = { "sent" };
+      std::vector<ustring> draft_tags = { "draft" };
+      std::vector<ustring> excluded_tags = { "muted", "spam", "deleted" };
 
-      void add_sent_message (ustring, vector<ustring>);
+      void add_sent_message (ustring, std::vector<ustring>);
       void add_draft_message (ustring);
-      void add_message_with_tags (ustring fname, vector<ustring> tags);
+      void add_message_with_tags (ustring fname, std::vector<ustring> tags);
       void remove_message (ustring);
   };
 
   /* exceptions */
-  class database_error : public runtime_error {
+  class database_error : public std::runtime_error {
     public:
       database_error (const char *);
 

--- a/src/log.hh
+++ b/src/log.hh
@@ -16,8 +16,6 @@
 
 # include <glibmm/threads.h>
 
-using namespace std;
-
 namespace Astroid {
   enum LogLevel {
     debug,
@@ -38,17 +36,17 @@ namespace Astroid {
   class Log {
     private:
       enum LogLevel _next_level;
-      stringstream  _next_line;
+      std::stringstream  _next_line;
 
-      mutex m_outstreams;
-      vector <ostream *> out_streams;
-      vector <LogView *> log_views;
+      std::mutex m_outstreams;
+      std::vector <std::ostream *> out_streams;
+      std::vector <LogView *> log_views;
 
       // this is the key: std::endl is a template function, and this is the signature of that function (For std::ostream).
       using endl_type = std::ostream&(std::ostream&);
 
-      queue <LogLine> lines;
-      mutex m_lines;
+      std::queue <LogLine> lines;
+      std::mutex m_lines;
 
       void flush_log ();
       Glib::Dispatcher d_flush;
@@ -77,8 +75,8 @@ namespace Astroid {
         return *this;
       }
 
-      void add_out_stream (ostream *);
-      void del_out_stream (ostream *);
+      void add_out_stream (std::ostream *);
+      void del_out_stream (std::ostream *);
       void add_log_view   (LogView *);
       void del_log_view   (LogView *);
   };

--- a/src/main_window.hh
+++ b/src/main_window.hh
@@ -1,6 +1,7 @@
 # pragma once
 
 # include <atomic>
+# include <functional>
 
 # include <gtkmm.h>
 # include <gtkmm/window.h>
@@ -11,8 +12,6 @@
 # include "modes/mode.hh"
 # include "modes/keybindings.hh"
 # include "actions/action_manager.hh"
-
-using namespace std;
 
 namespace Astroid {
   class Notebook : public Gtk::Notebook {
@@ -45,7 +44,7 @@ namespace Astroid {
 
       bool is_command = false;
       void enable_command (CommandBar::CommandMode, ustring,
-          function<void(ustring)>);
+          std::function<void(ustring)>);
       void disable_command ();
       void on_command_mode_changed ();
 
@@ -79,7 +78,7 @@ namespace Astroid {
 
       void on_update_title ();
 
-      static atomic<uint> nextid;
+      static std::atomic<uint> nextid;
   };
 
 }

--- a/src/message_thread.hh
+++ b/src/message_thread.hh
@@ -9,8 +9,6 @@
 # include "astroid.hh"
 # include "utils/address.hh"
 
-using namespace std;
-
 namespace Astroid {
   class Message : public Glib::Object {
     public:
@@ -58,13 +56,13 @@ namespace Astroid {
       ustring date ();
       ustring pretty_date ();
       ustring pretty_verbose_date (bool = false);
-      vector<ustring> tags;
+      std::vector<ustring> tags;
 
       ustring viewable_text (bool, bool fallback_html = false);
-      vector<refptr<Chunk>> attachments ();
+      std::vector<refptr<Chunk>> attachments ();
       refptr<Chunk> get_chunk_by_id (int id);
 
-      vector<refptr<Chunk>> mime_messages ();
+      std::vector<refptr<Chunk>> mime_messages ();
 
       refptr<Glib::ByteArray> contents ();
       refptr<Glib::ByteArray> raw_contents ();
@@ -76,7 +74,7 @@ namespace Astroid {
   };
 
   /* exceptions */
-  class message_error : public runtime_error {
+  class message_error : public std::runtime_error {
     public:
       message_error (const char *);
 
@@ -90,7 +88,7 @@ namespace Astroid {
       bool in_notmuch;
       refptr<NotmuchThread> thread;
       ustring subject;
-      vector<refptr<Message>> messages;
+      std::vector<refptr<Message>> messages;
 
       void load_messages (Db *);
       void add_message (ustring);

--- a/src/modes/edit_message.hh
+++ b/src/modes/edit_message.hh
@@ -19,8 +19,6 @@
 # include "account_manager.hh"
 # include "thread_view/thread_view.hh"
 
-using namespace std;
-
 namespace Astroid {
   class EditMessage : public Mode {
     public:
@@ -59,7 +57,7 @@ namespace Astroid {
       ustring references;
       ustring inreplyto;
 
-      vector<shared_ptr<ComposeMessage::Attachment>> attachments;
+      std::vector<std::shared_ptr<ComposeMessage::Attachment>> attachments;
       void add_attachment (ComposeMessage::Attachment *);
       void attach_file ();
 
@@ -102,7 +100,7 @@ namespace Astroid {
       ComposeMessage * make_message ();
 
       ComposeMessage * sending_message;
-      atomic<bool> sending_in_progress;
+      std::atomic<bool> sending_in_progress;
       void send_message_finished (bool result);
 
       void prepare_message ();
@@ -151,8 +149,8 @@ namespace Astroid {
       void reset_entry (Gtk::Entry *);
 
       /* gvim config */
-      string gvim_cmd;
-      string gvim_args;
+      std::string gvim_cmd;
+      std::string gvim_args;
 
       AccountManager * accounts;
 

--- a/src/modes/forward_message.cc
+++ b/src/modes/forward_message.cc
@@ -13,10 +13,11 @@
 # include "utils/address.hh"
 # include "chunk.hh"
 
-using namespace std;
-
 namespace Astroid {
   ForwardMessage::ForwardMessage (MainWindow * mw, refptr<Message> _msg) : EditMessage (mw) {
+    using std::endl;
+    using std::string;
+
     msg = _msg;
 
     log << info << "fwd: forwarding message " << msg->mid << endl;
@@ -35,7 +36,7 @@ namespace Astroid {
     } else {
 
       /* quote original message */
-      ostringstream quoted;
+      std::ostringstream quoted;
 
       ustring quoting_a = ustring::compose (astroid->config->config.get<string> ("mail.forward.quote_line"),
           Address(msg->sender.raw()).fail_safe_name(), msg->pretty_verbose_date());
@@ -89,6 +90,7 @@ namespace Astroid {
   }
 
   void ForwardMessage::on_message_sent_attempt_received (bool res) {
+    using std::endl;
     if (res) {
       log << info << "fwd: message successfully sent, adding passed tag to original." << endl;
 

--- a/src/modes/forward_message.hh
+++ b/src/modes/forward_message.hh
@@ -1,12 +1,8 @@
 # pragma once
 
-# include <iostream>
-
 # include "astroid.hh"
 # include "proto.hh"
 # include "edit_message.hh"
-
-using namespace std;
 
 namespace Astroid {
   class ForwardMessage : public EditMessage {

--- a/src/modes/help_mode.hh
+++ b/src/modes/help_mode.hh
@@ -1,16 +1,11 @@
 # pragma once
 
-# include <iostream>
-# include <atomic>
-
 # include <gtkmm.h>
 # include <webkit/webkit.h>
 
 # include "astroid.hh"
 # include "proto.hh"
 # include "mode.hh"
-
-using namespace std;
 
 namespace Astroid {
   class HelpMode : public Mode {

--- a/src/modes/keybindings.cc
+++ b/src/modes/keybindings.cc
@@ -8,16 +8,18 @@
 
 # include "log.hh"
 
-using namespace std;
+using std::function;
+using std::vector;
+using std::endl;
 
 namespace Astroid {
 
   /* Keybindings {{{ */
-  atomic<bool> Keybindings::user_bindings_loaded (false);
+  std::atomic<bool> Keybindings::user_bindings_loaded (false);
   const char * Keybindings::user_bindings_file = "keybindings";
-  vector<Key>  Keybindings::user_bindings;
+  std::vector<Key>  Keybindings::user_bindings;
 
-  map<guint, ustring> keynames = {
+  std::map<guint, ustring> keynames = {
     { GDK_KEY_Down,   "Down" },
     { GDK_KEY_Up,     "Up" },
     { GDK_KEY_Tab,    "Tab" },
@@ -31,6 +33,7 @@ namespace Astroid {
     if (!user_bindings_loaded) {
       user_bindings_loaded = true;
 
+      using bfs::path;
       path bindings_file = astroid->config->config_dir / path (user_bindings_file);
 
       if (exists(bindings_file)) {
@@ -477,7 +480,7 @@ namespace Astroid {
       try {
         ustring kk = keynames.at (key);
         s += kk;
-      } catch (exception &ex) {
+      } catch (std::exception &ex) {
         s += ustring::compose ("%1", key);
       }
     }

--- a/src/modes/keybindings.hh
+++ b/src/modes/keybindings.hh
@@ -4,8 +4,6 @@
 # include <functional>
 # include <atomic>
 
-using namespace std;
-
 namespace Astroid {
   struct Key {
     Key ();
@@ -37,13 +35,13 @@ namespace Astroid {
   };
 
   /* exceptions */
-  class keyspec_error : public runtime_error {
+  class keyspec_error : public std::runtime_error {
     public:
       keyspec_error (const char *);
 
   };
 
-  class duplicatekey_error : public runtime_error {
+  class duplicatekey_error : public std::runtime_error {
     public:
       duplicatekey_error (const char *);
 
@@ -57,34 +55,34 @@ namespace Astroid {
       ustring title; /* title of keybinding set */
       bool loghandle = true; /* log handling */
 
-      typedef pair<Key, function<bool (Key)>> KeyBinding;
+      typedef std::pair<Key, std::function<bool (Key)>> KeyBinding;
 
-      void register_key (Key, ustring name, ustring help, function<bool (Key)>);
-      void register_key (ustring spec, ustring name, ustring help, function<bool (Key)>);
-
-      void register_key (Key,
-                         vector<Key>,
-                         ustring name,
-                         ustring help,
-                         function<bool (Key)>);
-
-      void register_key (ustring spec,
-                         vector<ustring>,
-                         ustring name,
-                         ustring help,
-                         function<bool (Key)>);
+      void register_key (Key, ustring name, ustring help, std::function<bool (Key)>);
+      void register_key (ustring spec, ustring name, ustring help, std::function<bool (Key)>);
 
       void register_key (Key,
-                         vector<ustring>,
+                         std::vector<Key>,
                          ustring name,
                          ustring help,
-                         function<bool (Key)>);
+                         std::function<bool (Key)>);
 
       void register_key (ustring spec,
-                         vector<Key>,
+                         std::vector<ustring>,
                          ustring name,
                          ustring help,
-                         function<bool (Key)>);
+                         std::function<bool (Key)>);
+
+      void register_key (Key,
+                         std::vector<ustring>,
+                         ustring name,
+                         ustring help,
+                         std::function<bool (Key)>);
+
+      void register_key (ustring spec,
+                         std::vector<Key>,
+                         ustring name,
+                         ustring help,
+                         std::function<bool (Key)>);
 
       bool handle (GdkEventKey *);
 
@@ -94,14 +92,14 @@ namespace Astroid {
       ustring help ();
 
     private:
-      map<Key, function<bool (Key)>> keys;
+      std::map<Key, std::function<bool (Key)>> keys;
 
     public:
-      static vector<Key>  user_bindings;
-      static atomic<bool> user_bindings_loaded;
+      static std::vector<Key>  user_bindings;
+      static std::atomic<bool> user_bindings_loaded;
       static const char * user_bindings_file;
 
-      static map<guint, ustring> keynames;
+      static std::map<guint, ustring> keynames;
   };
 }
 

--- a/src/modes/log_view.hh
+++ b/src/modes/log_view.hh
@@ -6,8 +6,6 @@
 # include "mode.hh"
 # include "log.hh"
 
-using namespace std;
-
 namespace Astroid {
   class LogView : public Mode {
     public:

--- a/src/modes/mode.cc
+++ b/src/modes/mode.cc
@@ -86,6 +86,7 @@ namespace Astroid {
 
   void Mode::close (bool force) {
     /* close current page */
+    using std::endl;
     if (main_window->notebook.get_n_pages() > 1) {
       int c = main_window->notebook.get_current_page ();
 
@@ -105,8 +106,9 @@ namespace Astroid {
 
   void Mode::ask_yes_no (
       ustring question,
-      function <void (bool)> closure)
+      std::function <void (bool)> closure)
   {
+    using std::endl;
     log << info << "mode: " << question << endl;
 
     if (yes_no_waiting || multi_waiting) {
@@ -122,6 +124,7 @@ namespace Astroid {
   }
 
   void Mode::answer_yes_no (bool yes) {
+    using std::endl;
     rev_yes_no->set_reveal_child (false);
 
     if (yes) {
@@ -142,6 +145,7 @@ namespace Astroid {
 
   bool Mode::multi_key (Keybindings & kb, Key /* k */)
   {
+    using std::endl;
     log << info << "mode: starting multi key." << endl;
 
     if (yes_no_waiting || multi_waiting) {

--- a/src/modes/mode.hh
+++ b/src/modes/mode.hh
@@ -2,13 +2,10 @@
 
 # include <gtkmm.h>
 # include <atomic>
-
-# include <list>
+# include <functional>
 
 # include "proto.hh"
 # include "keybindings.hh"
-
-using namespace std;
 
 namespace Astroid {
   class Mode : public Gtk::Box {
@@ -19,7 +16,7 @@ namespace Astroid {
       void set_main_window (MainWindow *);
       MainWindow * main_window;
 
-      atomic<bool> invincible;
+      std::atomic<bool> invincible;
       virtual void close (bool = false);
 
     private:
@@ -30,7 +27,7 @@ namespace Astroid {
       Gtk::Label    * label_yes_no;
 
       bool yes_no_waiting = false;
-      function <void (bool)> yes_no_closure = NULL;
+      std::function <void (bool)> yes_no_closure = NULL;
       void answer_yes_no (bool);
       void on_yes ();
       void on_no ();
@@ -51,7 +48,7 @@ namespace Astroid {
       bool on_key_press_event (GdkEventKey *event) override;
       virtual Keybindings * get_keys ();
 
-      void ask_yes_no (ustring, function<void(bool)>);
+      void ask_yes_no (ustring, std::function<void(bool)>);
       bool multi_key (Keybindings &, Key);
 
       bool mode_key_handler (GdkEventKey *);

--- a/src/modes/paned_mode.hh
+++ b/src/modes/paned_mode.hh
@@ -1,14 +1,10 @@
 # pragma once
 
-# include <string>
-
 # include <gtkmm.h>
 # include <gtkmm/box.h>
 # include <gtkmm/widget.h>
 
 # include "mode.hh"
-
-using namespace std;
 
 namespace Astroid {
   /* a virtual mode class with two panes */

--- a/src/modes/raw_message.hh
+++ b/src/modes/raw_message.hh
@@ -1,9 +1,6 @@
 # include "proto.hh"
-# include "astroid.hh"
 
 # include "mode.hh"
-
-using namespace std;
 
 namespace Astroid {
   class RawMessage : public Mode {

--- a/src/modes/reply_message.hh
+++ b/src/modes/reply_message.hh
@@ -1,12 +1,7 @@
 # pragma once
 
-# include <iostream>
-
-# include "astroid.hh"
 # include "proto.hh"
 # include "edit_message.hh"
-
-using namespace std;
 
 namespace Astroid {
   class ReplyMessage : public EditMessage {

--- a/src/modes/thread_index/thread_index.hh
+++ b/src/modes/thread_index/thread_index.hh
@@ -1,6 +1,6 @@
 # pragma once
 
-# include <string>
+# include <vector>
 
 # include <gtkmm.h>
 # include <gtkmm/box.h>
@@ -10,9 +10,6 @@
 # include <notmuch.h>
 
 # include "modes/paned_mode.hh"
-
-
-using namespace std;
 
 namespace Astroid {
 
@@ -54,6 +51,6 @@ namespace Astroid {
 
     private:
       notmuch_sort_t sort;
-      vector<ustring> sort_strings = { "oldest", "newest", "messageid", "unsorted" };
+      std::vector<ustring> sort_strings = { "oldest", "newest", "messageid", "unsorted" };
   };
 }

--- a/src/modes/thread_index/thread_index_list_cell_renderer.hh
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.hh
@@ -1,12 +1,12 @@
 # pragma once
 
+# include <vector>
+
 # include <gtkmm.h>
 # include <gtkmm/cellrenderer.h>
 
 # include "proto.hh"
 # include "db.hh"
-
-using namespace std;
 
 namespace Astroid {
   class ThreadIndexListCellRenderer : public Gtk::CellRenderer {
@@ -20,7 +20,7 @@ namespace Astroid {
 
       /* these tags are displayed otherwisely, so they are not
        * shown explicitly: MUST BE SORTED */
-      const vector<ustring> hidden_tags =
+      const std::vector<ustring> hidden_tags =
               { "attachment", "flagged", "unread"
               };
 

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -83,6 +83,8 @@ namespace Astroid {
    * ---------
    */
   ThreadIndexListView::ThreadIndexListView (ThreadIndex * _thread_index, Glib::RefPtr<ThreadIndexListStore> store) {
+    using bfs::path;
+
     set_name ("ThreadIndexListView");
 
     thread_index = _thread_index;

--- a/src/modes/thread_index/thread_index_list_view.hh
+++ b/src/modes/thread_index/thread_index_list_view.hh
@@ -13,8 +13,6 @@
 
 # include "notmuch.h"
 
-using namespace std;
-
 namespace Astroid {
   /* the list view consists of:
    * - a scolled window (which may be paned)
@@ -109,7 +107,7 @@ namespace Astroid {
       void on_refreshed ();
 
     private:
-      chrono::time_point<chrono::steady_clock> last_redraw;
+      std::chrono::time_point<std::chrono::steady_clock> last_redraw;
       bool redraw ();
   };
 

--- a/src/modes/thread_view/theme.cc
+++ b/src/modes/thread_view/theme.cc
@@ -15,13 +15,15 @@ using namespace std;
 using namespace boost::filesystem;
 
 namespace Astroid {
-  atomic<bool> Theme::theme_loaded (false);
+  std::atomic<bool> Theme::theme_loaded (false);
   const char * Theme::thread_view_html_f = "ui/thread-view.html";
   const char * Theme::thread_view_scss_f  = "ui/thread-view.scss";
   ustring Theme::thread_view_html;
   ustring Theme::thread_view_css;
 
   Theme::Theme () {
+    using bfs::path;
+    using std::endl;
     log << debug << "theme: loading.." << endl;
 
     /* load css, html and DOM objects */
@@ -83,8 +85,8 @@ namespace Astroid {
       }
 
       std::ifstream tv_html_f (tv_html.c_str());
-      istreambuf_iterator<char> eos; // default is eos
-      istreambuf_iterator<char> tv_iit (tv_html_f);
+      std::istreambuf_iterator<char> eos; // default is eos
+      std::istreambuf_iterator<char> tv_iit (tv_html_f);
 
       thread_view_html.append (tv_iit, eos);
       tv_html_f.close ();
@@ -106,6 +108,7 @@ namespace Astroid {
     /* - https://github.com/sass/libsass/blob/master/docs/api-doc.md
      * - https://github.com/sass/libsass/blob/master/docs/api-context-example.md
      */
+    using std::endl;
 
     log << info << "theme: processing: " << scsspath << endl;
 
@@ -134,7 +137,7 @@ namespace Astroid {
     return ustring (output);
   }
 
-  bool Theme::check_theme_version (path p) {
+  bool Theme::check_theme_version (bfs::path p) {
     /* check version found in first line in file */
 
     std::ifstream f (p.c_str ());
@@ -143,7 +146,7 @@ namespace Astroid {
     int version;
     f >> vline >> vline >> version;
 
-    log << debug << "tv: testing version: " << version << endl;
+    log << debug << "tv: testing version: " << version << std::endl;
 
     f.close ();
 

--- a/src/modes/thread_view/theme.hh
+++ b/src/modes/thread_view/theme.hh
@@ -5,15 +5,14 @@
 
 # include "proto.hh"
 
-using namespace std;
-using namespace boost::filesystem;
+namespace bfs = boost::filesystem;
 
 namespace Astroid {
   class Theme {
     public:
       Theme ();
 
-      static atomic<bool> theme_loaded;
+      static std::atomic<bool> theme_loaded;
       static const char *  thread_view_html_f;
       static const char *  thread_view_scss_f;
       static ustring       thread_view_html;
@@ -22,7 +21,7 @@ namespace Astroid {
       const int THEME_VERSION = 2;
 
     private:
-      bool check_theme_version (path);
+      bool check_theme_version (bfs::path);
       ustring process_scss (const char * scsspath);
   };
 }

--- a/src/modes/thread_view/thread_view.hh
+++ b/src/modes/thread_view/thread_view.hh
@@ -1,23 +1,19 @@
 # pragma once
 
-# include <iostream>
 # include <atomic>
 # include <map>
+# include <vector>
+# include <string>
 
 # include <gtkmm.h>
 # include <webkit/webkit.h>
-# include <boost/filesystem.hpp>
 
-# include "astroid.hh"
 # include "proto.hh"
 # include "modes/mode.hh"
 # include "message_thread.hh"
 # include "theme.hh"
 
 # include "web_inspector.hh"
-
-using namespace std;
-using namespace boost::filesystem;
 
 namespace Astroid {
   extern "C" bool ThreadView_on_load_changed (
@@ -64,12 +60,12 @@ namespace Astroid {
       /* resources */
       bool    enable_mathjax;
       ustring mathjax_uri_prefix;
-      vector<ustring> mathjax_only_tags;
+      std::vector<ustring> mathjax_only_tags;
       ustring home_uri;           // relative url for requests
       bool    math_is_on = false; // for this thread
 
       bool    enable_code_prettify;
-      vector<ustring> code_prettify_only_tags;
+      std::vector<ustring> code_prettify_only_tags;
       ustring code_prettify_prefix; // add run_prettify.js to this
       ustring code_prettify_code_tag;
       bool    enable_code_prettify_for_patches;
@@ -141,7 +137,7 @@ namespace Astroid {
            * first element is always empty and represents the message
            * itself.
            */
-          vector<Element> elements;
+          std::vector<Element> elements;
           unsigned int    current_element;
           Element * get_current_element ();
       };
@@ -180,7 +176,7 @@ namespace Astroid {
       WebKitWebInspector * web_inspector;
 
 
-      atomic<bool> wk_loaded;
+      std::atomic<bool> wk_loaded;
 
       /* rendering */
       void render ();
@@ -244,7 +240,7 @@ namespace Astroid {
           ustring         selector);
 
     public:
-      static string assemble_data_uri (ustring, gchar *&, gsize);
+      static std::string assemble_data_uri (ustring, gchar *&, gsize);
 
       /* event wrappers */
       bool on_load_changed (
@@ -295,7 +291,7 @@ namespace Astroid {
       type_signal_ready signal_ready ();
 
       void emit_ready ();
-      atomic<bool> ready; // all messages and elements rendered
+      std::atomic<bool> ready; // all messages and elements rendered
 
       /* action on element */
       typedef sigc::signal <void, unsigned int, ElementAction> type_element_action;

--- a/src/modes/thread_view/web_inspector.cc
+++ b/src/modes/thread_view/web_inspector.cc
@@ -20,7 +20,7 @@ namespace Astroid {
       WebKitWebView          * web_view)
   {
     /* set up inspector window */
-    log << info << "tv: starting conversation inspector.." << endl;
+    log << info << "tv: starting conversation inspector.." << std::endl;
     inspector_window = new Gtk::Window ();
     inspector_window->set_default_size (600, 600);
     if (thread)
@@ -41,7 +41,7 @@ namespace Astroid {
   }
 
   bool ThreadView::show_inspector (WebKitWebInspector * wi) {
-    log << info << "tv: show inspector.." << endl;
+    log << info << "tv: show inspector.." << std::endl;
 
     inspector_window->show_all ();
 

--- a/src/poll.hh
+++ b/src/poll.hh
@@ -4,10 +4,9 @@
 # include "log.hh"
 
 # include <mutex>
+# include <chrono>
 # include <glibmm/threads.h>
 # include <glibmm/iochannel.h>
-
-using namespace std;
 
 namespace Astroid {
   class Poll {
@@ -21,7 +20,7 @@ namespace Astroid {
       static const int DEFAULT_POLL_INTERVAL; // 60
 
     private:
-      mutex m_dopoll;
+      std::mutex m_dopoll;
 
       int poll_interval = 0;
       bool auto_polling_enabled = true;
@@ -29,8 +28,8 @@ namespace Astroid {
       void do_poll ();
       bool periodic_polling ();
 
-      chrono::time_point<chrono::steady_clock> t0; // start time of poll
-      chrono::time_point<chrono::steady_clock> last_poll;
+      std::chrono::time_point<std::chrono::steady_clock> t0; // start time of poll
+      std::chrono::time_point<std::chrono::steady_clock> last_poll;
 
 # ifdef HAVE_NOTMUCH_GET_REV
       unsigned long last_good_before_poll_revision = 0;

--- a/src/utils/address.hh
+++ b/src/utils/address.hh
@@ -7,8 +7,6 @@
 
 # include <gmime/gmime.h>
 
-using namespace std;
-
 namespace Astroid {
 
   class Address {
@@ -39,7 +37,7 @@ namespace Astroid {
       AddressList (Address);
       AddressList (ustring);
 
-      vector<Address> addresses;
+      std::vector<Address> addresses;
       ustring str ();
 
       AddressList& operator+= (const Address &);

--- a/src/utils/date_utils.hh
+++ b/src/utils/date_utils.hh
@@ -2,8 +2,6 @@
 
 # include "astroid.hh"
 
-using namespace std;
-
 namespace Astroid {
   class Date {
     public:
@@ -18,8 +16,8 @@ namespace Astroid {
       //
       // See http://developer.gnome.org/glib/2.32/glib-GDateTime.html#g-date-time-format
 
-      static const vector<ustring> pretty_dates;
-      static const vector<ustring> pretty_verbose_dates;
+      static const std::vector<ustring> pretty_dates;
+      static const std::vector<ustring> pretty_verbose_dates;
 
       // Date format for dates within the current year, i.e. Nov 8
       static ustring same_year;

--- a/src/utils/gravatar.hh
+++ b/src/utils/gravatar.hh
@@ -3,8 +3,6 @@
 # include "proto.hh"
 # include <vector>
 
-using namespace std;
-
 namespace Astroid {
   class Gravatar {
     public:
@@ -21,7 +19,7 @@ namespace Astroid {
         RETRO,
       };
 
-      static vector<ustring> DefaultStr;
+      static std::vector<ustring> DefaultStr;
 
       static ustring get_image_uri (ustring, enum Default, int = Gravatar::DEFAULT_SIZE);
 

--- a/src/utils/mail_quote.hh
+++ b/src/utils/mail_quote.hh
@@ -3,8 +3,6 @@
 # include "astroid.hh"
 # include "proto.hh"
 
-using namespace std;
-
 namespace Astroid {
 
   class MailQuotes {

--- a/src/utils/ustring_utils.hh
+++ b/src/utils/ustring_utils.hh
@@ -4,8 +4,6 @@
 
 # include "astroid.hh"
 
-using namespace std;
-
 namespace Astroid {
   class UstringUtils {
     public:

--- a/src/utils/vector_utils.hh
+++ b/src/utils/vector_utils.hh
@@ -3,23 +3,21 @@
 # include "astroid.hh"
 # include <vector>
 
-using namespace std;
-
 namespace Astroid {
-  template<class T> bool has (vector<T> v, T e) {
+  template<class T> bool has (std::vector<T> v, T e) {
     return (find(v.begin (), v.end (), e) != v.end ());
   }
 
   class VectorUtils {
     public:
 
-      static vector<ustring> split_and_trim (ustring & str, ustring delim);
-      static ustring concat (vector<ustring> &, ustring, vector<ustring>);
-      static ustring concat_tags (vector<ustring>);
-      static ustring concat_authors (vector<ustring>);
+      static std::vector<ustring> split_and_trim (ustring & str, ustring delim);
+      static ustring concat (std::vector<ustring> &, ustring, std::vector<ustring>);
+      static ustring concat_tags (std::vector<ustring>);
+      static ustring concat_authors (std::vector<ustring>);
 
-      static const vector<ustring> stop_ons_tags;
-      static const vector<ustring> stop_ons_auth;
+      static const std::vector<ustring> stop_ons_tags;
+      static const std::vector<ustring> stop_ons_auth;
 
   };
 }

--- a/test/test_common.hh
+++ b/test/test_common.hh
@@ -2,11 +2,11 @@
 
 # include "astroid.hh"
 # include "log.hh"
-
-using namespace Astroid;
+# include "proto.hh"
 
 void setup () {
-  Astroid::astroid = new Astroid::Astroid ();
+  using Astroid::astroid;
+  astroid = new Astroid::Astroid ();
   astroid->main_test ();
 }
 

--- a/test/test_composed_message.cc
+++ b/test/test_composed_message.cc
@@ -4,12 +4,12 @@
 
 # include "test_common.hh"
 # include "compose_message.hh"
-using namespace std;
 
 BOOST_AUTO_TEST_SUITE(Composing)
 
   BOOST_AUTO_TEST_CASE(compose_read_test)
   {
+    using Astroid::ComposeMessage;
     setup ();
 
     ComposeMessage * c = new ComposeMessage ();

--- a/test/test_convert_error.cc
+++ b/test/test_convert_error.cc
@@ -7,8 +7,11 @@
 # include "message_thread.hh"
 # include "glibmm.h"
 
-using namespace std;
+using std::cout;
+using std::endl;
+using std::locale;
 
+using Astroid::ustring;
 
 BOOST_AUTO_TEST_SUITE(Reading)
 
@@ -36,7 +39,7 @@ BOOST_AUTO_TEST_SUITE(Reading)
 
     BOOST_WARN_MESSAGE (Glib::get_charset (), "The current locale is not utf8");
 
-    string current_locale;
+    std::string current_locale;
     Glib::get_charset (current_locale);
     BOOST_TEST_MESSAGE ("locale: " + current_locale);
 
@@ -49,7 +52,7 @@ BOOST_AUTO_TEST_SUITE(Reading)
 
     ustring fname = "test/mail/test_mail/convert_error.eml";
 
-    Message m (fname);
+    Astroid::Message m (fname);
 
     BOOST_CHECK_NO_THROW (m.viewable_text (false));
 
@@ -62,21 +65,21 @@ BOOST_AUTO_TEST_SUITE(Reading)
 
     ustring fname = "test/mail/test_mail/bad-convert-error.eml";
 
-    Message msg (fname);
+    Astroid::Message msg (fname);
     /* quote original message */
-    ostringstream quoted;
+    std::ostringstream quoted;
 
     ustring quoting_a = ustring::compose ("Excerpts from %1's message of %2:",
-        Address(msg.sender.raw()).fail_safe_name(), msg.pretty_verbose_date());
+        Astroid::Address(msg.sender.raw()).fail_safe_name(), msg.pretty_verbose_date());
 
     quoted  << quoting_a.raw ()
             << endl;
 
-    string vt = msg.viewable_text(false);
-    stringstream sstr (vt);
+    std::string vt = msg.viewable_text(false);
+    std::stringstream sstr (vt);
     while (sstr.good()) {
-      string line;
-      getline (sstr, line);
+      std::string line;
+      std::getline (sstr, line);
       quoted << ">";
 
       if (line[0] != '>')
@@ -89,8 +92,8 @@ BOOST_AUTO_TEST_SUITE(Reading)
 
 
     /* test writing out */
-    string name = tmpnam (NULL);
-    Astroid::log << test << "writing to tmp file " << name << endl;
+    std::string name = tmpnam (NULL);
+    Astroid::log << Astroid::test << "writing to tmp file " << name << endl;
     std::fstream tmpfile (name, std::fstream::out);
 
     tmpfile << "From: test@test.no" << endl;
@@ -101,8 +104,8 @@ BOOST_AUTO_TEST_SUITE(Reading)
     tmpfile << endl;
     tmpfile.close ();
 
-    Astroid::log << test << "removing tmp file" << endl;
-    remove (name);
+    Astroid::log << Astroid::test << "removing tmp file" << endl;
+    std::remove (name.c_str());
 
     teardown ();
   }

--- a/test/test_generic.cc
+++ b/test/test_generic.cc
@@ -4,7 +4,6 @@
 
 # include "test_common.hh"
 # include "compose_message.hh"
-using namespace std;
 
 BOOST_AUTO_TEST_SUITE(Generic)
 

--- a/test/test_mime_message.cc
+++ b/test/test_mime_message.cc
@@ -8,6 +8,8 @@
 # include "glibmm.h"
 
 using namespace std;
+using Astroid::Message;
+using Astroid::ustring;
 
 
 BOOST_AUTO_TEST_SUITE(Reading)

--- a/test/test_no_newline_msg.cc
+++ b/test/test_no_newline_msg.cc
@@ -8,6 +8,9 @@
 # include "glibmm.h"
 
 using namespace std;
+using Astroid::ustring;
+using Astroid::Message;
+
 
 
 BOOST_AUTO_TEST_SUITE(Reading)

--- a/test/test_non_existant_file.cc
+++ b/test/test_non_existant_file.cc
@@ -8,7 +8,6 @@
 # include "message_thread.hh"
 # include "glibmm.h"
 # include "chunk.hh"
-using namespace std;
 
 using namespace boost::filesystem;
 
@@ -18,17 +17,25 @@ BOOST_AUTO_TEST_SUITE(Reading)
   {
     setup ();
 
-    string fname = "test/mail/test_mail/this-one-should-not-exist.eml";
+    std::string fname = "test/mail/test_mail/this-one-should-not-exist.eml";
 
     BOOST_CHECK (!exists(fname));
 
-    BOOST_CHECK_THROW(Message m (fname), message_error);
+    BOOST_CHECK_THROW(Astroid::Message m (fname), Astroid::message_error);
 
     teardown ();
   }
 
   BOOST_AUTO_TEST_CASE(out_of_sync)
   {
+    using Astroid::log;
+    using Astroid::test;
+    using std::endl;
+    using Astroid::Message;
+    using Astroid::Db;
+    using Astroid::AddressList;
+    using Astroid::ustring;
+
     setup ();
 
     /* open other email and make copy */
@@ -50,7 +57,6 @@ BOOST_AUTO_TEST_SUITE(Reading)
     ustring mid = "oos@asdf.com";
     Db db(Db::DATABASE_READ_ONLY);
     db.on_message (mid, [&](notmuch_message_t * msg) {
-
         Astroid::log << test << "trying to open deleted file." << endl;
 
         oos = new Message (msg, 0);

--- a/test/test_open_db.cc
+++ b/test/test_open_db.cc
@@ -9,6 +9,7 @@
 # include "glibmm.h"
 using namespace std;
 
+using namespace Astroid;
 using namespace boost::filesystem;
 
 BOOST_AUTO_TEST_SUITE(DbTest)

--- a/test/test_theme.cc
+++ b/test/test_theme.cc
@@ -7,8 +7,8 @@
 
 # include "modes/thread_view/theme.hh"
 
-
 using namespace std;
+using Astroid::ustring;
 
 
 BOOST_AUTO_TEST_SUITE(Theme)


### PR DESCRIPTION
Also start cleaning up includes. The only "using" i left was for ptree in src/config.hh. I hope (and think) this won't do any damage. I could do something with that (namespace/type alias) if you want.

When there was an issue in a .cc-file I also tried to reduce pollution of global
namespace. Especially have a look at those. We can can come up with a general rule
(style guide) for those things, and I can fix that. Or you merge it and we fix
remaining style issues later.

(As a side effect I found a fix for #60)