### PR TITLE
Fix #60: test_theme failure due to use after free.

### DIFF
--- a/src/modes/thread_view/theme.cc
+++ b/src/modes/thread_view/theme.cc
@@ -132,9 +132,10 @@ namespace Astroid {
     }
 
     const char * output = sass_context_get_output_string(context);
+    ustring output_str(output);
     sass_delete_file_context (file_ctx);
 
-    return ustring (output);
+    return output_str;
   }
 
   bool Theme::check_theme_version (bfs::path p) {


### PR DESCRIPTION
sass_delete_file_context also frees output_string. So we
need to copy output before deleting the context.