### PR TITLE
Speed up hacking by minimizing includes of build_config.hh

### DIFF
--- a/src/astroid.cc
+++ b/src/astroid.cc
@@ -33,6 +33,7 @@ using namespace boost::filesystem;
 /* globally available static instance of the Astroid */
 Astroid::Astroid * (Astroid::astroid);
 Astroid::Log Astroid::log;
+const char* const Astroid::Astroid::version = GIT_DESC;
 
 namespace Astroid {
   Astroid::Astroid () {
@@ -41,14 +42,14 @@ namespace Astroid {
 
     log.add_out_stream (&cout);
 
-    log << info << "welcome to astroid! - " << GIT_DESC << endl;
+    log << info << "welcome to astroid! - " << Astroid::version << endl;
 
     string charset;
     Glib::get_charset(charset);
     log << debug << "utf8: " << Glib::get_charset () << ", " << charset << endl;
 
     /* user agent */
-    user_agent = ustring::compose ("astroid/v%1 (https://github.com/gauteh/astroid)", GIT_DESC);
+    user_agent = ustring::compose ("astroid/v%1 (https://github.com/gauteh/astroid)", Astroid::version);
 
     /* gmime settings */
     g_mime_init (0); // utf-8 is default

--- a/src/astroid.hh
+++ b/src/astroid.hh
@@ -17,6 +17,7 @@ namespace Astroid {
 
       refptr<Gtk::Application> app;
 
+      static const char* const version;
       ustring user_agent;
 
       /* config */

--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -5,7 +5,6 @@
 # include <gtkmm/notebook.h>
 
 # include "astroid.hh"
-# include "build_config.hh"
 # include "poll.hh"
 # include "main_window.hh"
 # include "modes/mode.hh"
@@ -266,7 +265,7 @@ namespace Astroid {
 
   void MainWindow::set_title (ustring t) {
 
-    ustring tt = "Astroid (" GIT_DESC ")";
+    ustring tt = ustring::compose( "Astroid (%1)", Astroid::version);
 
     if (t.size() > 0) {
       tt = t + " - " + tt;

--- a/src/modes/edit_message.cc
+++ b/src/modes/edit_message.cc
@@ -24,7 +24,6 @@
 # include "chunk.hh"
 # include "utils/utils.hh"
 # include "utils/ustring_utils.hh"
-# include "build_config.hh"
 # include "log.hh"
 
 using namespace std;

--- a/src/modes/help_mode.cc
+++ b/src/modes/help_mode.cc
@@ -3,7 +3,7 @@
 # include "main_window.hh"
 # include "mode.hh"
 # include "help_mode.hh"
-# include "build_config.hh"
+# include "astroid.hh"
 
 # include <vector>
 # include <tuple>
@@ -97,13 +97,13 @@ namespace Astroid {
   void HelpMode::show_help (Mode * m) {
     set_label ("Help: " + m->get_keys ()->title);
 
-    ustring header =
-    "<b>Astroid</b> (" GIT_DESC ") \n"
+    ustring header = ustring::compose(
+    "<b>Astroid</b> (%1) \n"
     "\n"
     "Gaute Hope &lt;<a href=\"mailto:eg@gaute.vetsj.com\">eg@gaute.vetsj.com</a>&gt; (c) 2014"
     " (<i>Licenced under the GNU GPL v3</i>)\n"
     "<a href=\"https://github.com/gauteh/astroid\">https://github.com/gauteh/astroid</a> | <a href=\"mailto:astroidmail@googlegroups.com\">astroidmail@googlegroups.com</a>\n"
-    "\n";
+    "\n", Astroid::version);
 
     ustring help = header + generate_help (m);
 

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -29,7 +29,6 @@
 # include "modes/raw_message.hh"
 # include "modes/thread_index/thread_index.hh"
 # include "log.hh"
-# include "build_config.hh"
 # include "theme.hh"
 
 using namespace std;


### PR DESCRIPTION
astroid.cc still needs several seconds to compile, so I was
tempted to create a simple build_info.cc - but that seems to
be a little bit of overkill.
I also thought of removing Astroid::user_agent as it is not
used anywhere, but I don't know your plans for it ;)