### PR TITLE
Run: add run shell-command hooks, starting out with thread_index.run

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -50,7 +50,7 @@ namespace Astroid {
 
       home = cur_path / path("test/test_home");
 
-      log << LogLevel::test << "cf: using home directory: " << home.c_str () << endl;
+      log << LogLevel::test << "cf: using home and config_dir directory: " << home.c_str () << endl;
 
     } else {
       char * home_c = getenv ("HOME");
@@ -64,11 +64,15 @@ namespace Astroid {
     }
 
     /* default config */
-    char * config_home = getenv ("XDG_CONFIG_HOME");
-    if (config_home == NULL) {
-      config_dir = home / path(".config/astroid");
+    if (test) {
+      config_dir = home;
     } else {
-      config_dir = path(config_home) / path("astroid");
+      char * config_home = getenv ("XDG_CONFIG_HOME");
+      if (config_home == NULL) {
+        config_dir = home / path(".config/astroid");
+      } else {
+        config_dir = path(config_home) / path("astroid");
+      }
     }
 
     /* default data */

--- a/src/modes/keybindings.cc
+++ b/src/modes/keybindings.cc
@@ -43,10 +43,13 @@ namespace Astroid {
 
         /* the bindings file has the format:
          *
-         * ``` thread_index.next_thread=j thread_index.next_thread=Down
+         * ```
+         * thread_index.next_thread=j
+         * thread_index.next_thread=Down
          * thread_index.label=C-j
          *
-         * # thread_ ```
+         * # thread_
+         * ```
          *
          * blank lines, or lines starting with # are ignored. a keybinding can
          * be listed several times, in which case they will be interpreted as
@@ -136,6 +139,7 @@ namespace Astroid {
 
             k.name = name;
             k.allow_duplicate_name = true;
+            k.userdefined = true;
 
             user_run_bindings.push_back (std::make_pair (k, target));
 

--- a/src/modes/keybindings.cc
+++ b/src/modes/keybindings.cc
@@ -98,16 +98,19 @@ namespace Astroid {
             fnd = line.find ("(", fnd);
 
             if (fnd == std::string::npos) {
-              ustring erru = "invalid 'run'-keyspec";
-              log << error << "ky: " << erru << endl;
-              throw keyspec_error (erru.c_str ());
+              log << error <<  "ky: invalid 'run'-specification: no '('" << endl;
+              continue;
             }
 
             std::size_t rfnd = line.rfind ("=");
             if (rfnd == std::string::npos) {
-              ustring erru = "invalid 'run'-keyspec";
-              log << error << "ky: " << erru << endl;
-              throw keyspec_error (erru.c_str ());
+              log << error << "ky: invalid 'run'-specification: no '='" << endl;
+              continue;
+            }
+
+            if (rfnd < fnd) {
+              log << error << "ky: invalid 'run'-specification:  '=' before '('" << endl;
+              continue;
             }
 
             ustring keyspec = line.substr (rfnd+1, std::string::npos);
@@ -115,9 +118,13 @@ namespace Astroid {
 
             rfnd = line.rfind (")", rfnd);
             if (rfnd == std::string::npos) {
-              ustring erru = "invalid 'run'-keyspec";
-              log << error << "ky: " << erru << endl;
-              throw keyspec_error (erru.c_str ());
+              log << error << "ky: invalid 'run'-specfication: no ')'" << endl;
+              continue;
+            }
+
+            if (rfnd < fnd) {
+              log << error << "ky: invalid 'run'-specification: ')' before '('" << endl;
+              continue;
             }
 
             ustring target = line.substr (fnd + 1, rfnd - fnd -1);

--- a/src/modes/keybindings.cc
+++ b/src/modes/keybindings.cc
@@ -81,8 +81,18 @@ namespace Astroid {
           if (line.size () == 0) continue;
           if (line[0] == '#') continue;
 
+          std::size_t fnd;
+
+          /* check if this is a run line */
+          fnd = line.find (".run");
+          if (fnd != std::string::npos) {
+            log << debug << "ky: parsing hook: " << line << endl;
+
+
+          }
+
           /* cut off comments appended to the end of the line */
-          std::size_t fnd = line.find ("#");
+          fnd = line.find ("#");
           if (fnd != std::string::npos) {
             line = line.substr (0, fnd);
           }
@@ -109,10 +119,9 @@ namespace Astroid {
   Keybindings::Keybindings () {
   }
 
-  void set_prefix (ustring p) {
+  void Keybindings::set_prefix (ustring t, ustring p) {
+    title  = t;
     prefix = p;
-    log << debug << "ti: loading prefix: " << p << endl;
-
   }
 
   ustring Keybindings::short_help () {

--- a/src/modes/keybindings.cc
+++ b/src/modes/keybindings.cc
@@ -41,17 +41,31 @@ namespace Astroid {
 
         /* the bindings file has the format:
          *
-         * ```
-         * thread_index.next_thread=j
-         * thread_index.next_thread=Down
+         * ``` thread_index.next_thread=j thread_index.next_thread=Down
          * thread_index.label=C-j
          *
-         * # thread_
-         * ```
+         * # thread_ ```
          *
-         * blank lines, or lines starting with # are ignored. a keybinding
-         * can be listed several times, in which case they will be interpreted as
+         * blank lines, or lines starting with # are ignored. a keybinding can
+         * be listed several times, in which case they will be interpreted as
          * aliases for the same target.
+         *
+         * shell hooks follow the format:
+         *
+         *  thread_index.run(cmd)=key
+         *
+         *  it will be parsed by searching for:
+         *
+         *  1. prefix.run( 2. then search backwards for )= 3. split in cmd and
+         *  key
+         *
+         *  on run the arguments for the cmd need to be got from the current
+         *  mode and passed on.
+         *
+         *  on finished run the event [void on_run (bool success)] will be run,
+         *  with 'bool success' indicating a sucessfull run of the command. in
+         *  thread_index this will for instance be used to refresh the current
+         *  thread.
          */
 
         std::ifstream bf (bindings_file.c_str());
@@ -93,6 +107,12 @@ namespace Astroid {
   }
 
   Keybindings::Keybindings () {
+  }
+
+  void set_prefix (ustring p) {
+    prefix = p;
+    log << debug << "ti: loading prefix: " << p << endl;
+
   }
 
   ustring Keybindings::short_help () {

--- a/src/modes/keybindings.cc
+++ b/src/modes/keybindings.cc
@@ -437,12 +437,11 @@ namespace Astroid {
       /* b is now a matching binding */
       log << info << "ky: run, binding: " << name << " to: " << b->second << endl;
 
-      std::function <bool (Key)> f = bind (cb, _1, b->second);
-
       register_key (b->first,
                     b->first.name,
                     ustring::compose ("Run hook: %1", b->second),
-                    f);
+                    bind (cb, _1, b->second)
+                    );
 
       b++;
     }

--- a/src/modes/keybindings.hh
+++ b/src/modes/keybindings.hh
@@ -59,7 +59,7 @@ namespace Astroid {
       Keybindings ();
       static void init ();
 
-      void set_prefix (ustring);
+      void set_prefix (ustring title, ustring prefix);
 
       ustring title; /* title of keybinding set */
       bool loghandle = true; /* log handling */

--- a/src/modes/keybindings.hh
+++ b/src/modes/keybindings.hh
@@ -107,10 +107,11 @@ namespace Astroid {
 
     private:
       std::map<Key, std::function<bool (Key)>> keys;
-      ustring prefix = ""; /* used to load custom hooks */
+      ustring prefix = "";
 
       static std::vector<Key>  user_bindings;
       static std::vector<std::pair<Key, ustring>> user_run_bindings;
+
       static std::atomic<bool> user_bindings_loaded;
       static const char * user_bindings_file;
 

--- a/src/modes/keybindings.hh
+++ b/src/modes/keybindings.hh
@@ -23,6 +23,8 @@ namespace Astroid {
     bool unbound     = false;
     bool userdefined = false;
 
+    bool allow_duplicate_name = false; /* used for run targets */
+
     bool hasaliases = false; /* this is a master key with other aliases */
     bool isalias    = false; /* this key is an alias for another master key */
     const Key * master_key;
@@ -93,6 +95,9 @@ namespace Astroid {
                          ustring help,
                          std::function<bool (Key)>);
 
+      void register_run (ustring name,
+                         std::function<bool (Key, ustring)>);
+
       bool handle (GdkEventKey *);
 
       void clear ();
@@ -104,8 +109,8 @@ namespace Astroid {
       std::map<Key, std::function<bool (Key)>> keys;
       ustring prefix = ""; /* used to load custom hooks */
 
-    public:
       static std::vector<Key>  user_bindings;
+      static std::vector<std::pair<Key, ustring>> user_run_bindings;
       static std::atomic<bool> user_bindings_loaded;
       static const char * user_bindings_file;
 

--- a/src/modes/keybindings.hh
+++ b/src/modes/keybindings.hh
@@ -59,6 +59,8 @@ namespace Astroid {
       Keybindings ();
       static void init ();
 
+      void set_prefix (ustring);
+
       ustring title; /* title of keybinding set */
       bool loghandle = true; /* log handling */
 
@@ -100,6 +102,7 @@ namespace Astroid {
 
     private:
       std::map<Key, std::function<bool (Key)>> keys;
+      ustring prefix = ""; /* used to load custom hooks */
 
     public:
       static std::vector<Key>  user_bindings;

--- a/src/modes/thread_index/thread_index.cc
+++ b/src/modes/thread_index/thread_index.cc
@@ -60,8 +60,7 @@ namespace Astroid {
     list_view->set_cursor (Gtk::TreePath("0"));
 
     /* register keys {{{ */
-    keys.title = "ThreadIndex mode";
-    keys.set_prefix ("thread_index");
+    keys.set_prefix ("Thread Index", "thread_index");
 
     keys.register_key ("x", "thread_index.close_pane", "Close thread view pane if open",
         [&](Key k) {

--- a/src/modes/thread_index/thread_index.cc
+++ b/src/modes/thread_index/thread_index.cc
@@ -61,6 +61,7 @@ namespace Astroid {
 
     /* register keys {{{ */
     keys.title = "ThreadIndex mode";
+    keys.set_prefix ("thread_index");
 
     keys.register_key ("x", "thread_index.close_pane", "Close thread view pane if open",
         [&](Key k) {

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -16,6 +16,7 @@
 # include "modes/forward_message.hh"
 # include "message_thread.hh"
 # include "utils/utils.hh"
+# include "utils/cmd.hh"
 
 # include "command_bar.hh"
 
@@ -836,7 +837,24 @@ namespace Astroid {
           return true;
         });
 
+    keys->register_run ("thread_index.run",
+        [&] (Key k, ustring cmd) {
+          auto t = get_current_thread ();
+
+          if (t) {
+            cmd = ustring::compose (cmd, t->thread_id);
+            int r = Cmd ("thread_index.run", cmd).run ();
+
+            if (r == 0) {
+              Db db;
+              astroid->global_actions->emit_thread_updated (&db, t->thread_id);
+            }
+          }
+
+          return true;
+        });
   }
+
 
   bool ThreadIndexListView::multi_key_handler (
       ThreadIndexListView::multi_key_action maction,

--- a/src/utils/cmd.cc
+++ b/src/utils/cmd.cc
@@ -2,20 +2,22 @@
 # include "astroid.hh"
 # include "log.hh"
 # include "vector_utils.hh"
+# include "config.hh"
 
 # include <glibmm.h>
+# include <boost/filesystem.hpp>
 
 using std::endl;
 using std::string;
+namespace bfs = boost::filesystem;
 
 namespace Astroid {
-  Cmd::Cmd (ustring _prefix, ustring _cmd) {
+  Cmd::Cmd (ustring _prefix, ustring _cmd) : Cmd (_cmd) {
     prefix = _prefix + ": ";
-    cmd = _cmd;
   }
 
   Cmd::Cmd (ustring _cmd) {
-    cmd = _cmd;
+    cmd = substitute (_cmd);
   }
 
   int Cmd::run () {
@@ -40,6 +42,18 @@ namespace Astroid {
     }
 
     return exit;
+  }
+
+  ustring Cmd::substitute (const ustring _cmd) {
+    ustring ncmd = _cmd;
+
+    ustring key = "hooks::";
+    std::size_t fnd = ncmd.find (key);
+    if (fnd != std::string::npos) {
+      ncmd.replace (fnd, key.length (), (astroid->config->config_dir / bfs::path("hooks/")).c_str ());
+    }
+
+    return ncmd;
   }
 }
 

--- a/src/utils/cmd.cc
+++ b/src/utils/cmd.cc
@@ -1,0 +1,46 @@
+# include "cmd.hh"
+# include "astroid.hh"
+# include "log.hh"
+# include "vector_utils.hh"
+
+# include <glibmm.h>
+
+using std::endl;
+using std::string;
+
+namespace Astroid {
+  Cmd::Cmd (ustring _prefix, ustring _cmd) {
+    prefix = _prefix + ": ";
+    cmd = _cmd;
+  }
+
+  Cmd::Cmd (ustring _cmd) {
+    cmd = _cmd;
+  }
+
+  int Cmd::run () {
+    log << info << "cmd: running: " << cmd << endl;
+    string _stdout;
+    string _stderr;
+    int exit;
+
+    string _cmd = cmd;
+    Glib::spawn_command_line_sync (_cmd, &_stdout, &_stderr, &exit);
+
+    if (!_stdout.empty ()) {
+      for (auto &l : VectorUtils::split_and_trim (_stdout, "\n")) {
+        if (!l.empty ()) log << debug << "cmd: " << prefix << l << endl;
+      }
+    }
+
+    if (!_stderr.empty ()) {
+      for (auto &l : VectorUtils::split_and_trim (_stderr, "\n")) {
+        if (!l.empty ()) log << error << "cmd: " << prefix << l << endl;
+      }
+    }
+
+    return exit;
+  }
+}
+
+

--- a/src/utils/cmd.hh
+++ b/src/utils/cmd.hh
@@ -1,0 +1,23 @@
+# pragma once
+
+# include "astroid.hh"
+
+# include <mutex>
+# include <chrono>
+# include <glibmm/threads.h>
+# include <glibmm/iochannel.h>
+
+namespace Astroid {
+  class Cmd {
+    public:
+      Cmd (ustring prefix, ustring cmd);
+      Cmd (ustring cmd);
+
+      int run (); /* currently only in sync */
+
+    private:
+      ustring prefix;
+      ustring cmd;
+  };
+}
+

--- a/src/utils/cmd.hh
+++ b/src/utils/cmd.hh
@@ -18,6 +18,8 @@ namespace Astroid {
     private:
       ustring prefix;
       ustring cmd;
+
+      ustring substitute (ustring);
   };
 }
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -12,4 +12,5 @@ test_non_existant_file
 test_open_db
 test_mime_message
 test_theme
+test_keybindings
 

--- a/test/SConscript
+++ b/test/SConscript
@@ -50,5 +50,7 @@ testEnv.addUnitTest ('test_mime_message', ['test_mime_message.cc', source_objs])
 
 testEnv.addUnitTest ('test_theme', ['test_theme.cc', source_objs])
 
+testEnv.addUnitTest ('test_keybindings', ['test_keybindings.cc', source_objs])
+
 
 # all the tests added above are automatically added to the 'test' alias

--- a/test/test_home/keybindings
+++ b/test/test_home/keybindings
@@ -1,0 +1,17 @@
+# comment
+
+thread_index.next=J
+thread_index.next=k # alias and end of line comment
+
+thread_index.asdf = j
+
+# test
+test.a = k
+test.b=j
+test.b=j # double, should throw exception
+
+
+
+# unbound
+test.unbound2=1
+

--- a/test/test_home/keybindings
+++ b/test/test_home/keybindings
@@ -15,3 +15,10 @@ test.b=j # double, should throw exception
 # unbound
 test.unbound2=1
 
+
+# test some run targets
+
+test.run(echo %1)=n
+test.run(echo %1)=y
+
+

--- a/test/test_keybindings.cc
+++ b/test/test_keybindings.cc
@@ -16,6 +16,7 @@ BOOST_AUTO_TEST_SUITE(Theme)
   BOOST_AUTO_TEST_CASE(loading_keybindings)
   {
     using namespace Astroid;
+    using Astroid::log;
     setup ();
 
     Astroid::Keybindings::init ();
@@ -43,6 +44,28 @@ BOOST_AUTO_TEST_SUITE(Theme)
     BOOST_CHECK_THROW (
       keys.register_key ("a", "test.a", "duplicate keyspec", [&] (Key) { return true; }),
       duplicatekey_error);
+
+
+    /* test run hook */
+    ustring test_thread = "001";
+
+    auto f = [&] (Key k, ustring cmd) {
+      log << test << "key: run-hook got back: " << cmd << endl;
+
+      ustring final_cmd = ustring::compose (cmd, test_thread);
+      log << test << "key: would run: " << final_cmd << endl;
+
+      return true;
+    };
+
+    keys.register_run ("test.run", f);
+
+    Key n ("n");
+    GdkEventKey e;
+    e.keyval = n.key;
+
+    keys.handle (&e);
+
 
     teardown ();
   }

--- a/test/test_keybindings.cc
+++ b/test/test_keybindings.cc
@@ -6,12 +6,13 @@
 # include "glibmm.h"
 
 # include "modes/keybindings.hh"
+# include "utils/cmd.hh"
 
 using namespace std;
 using Astroid::ustring;
 
 
-BOOST_AUTO_TEST_SUITE(Theme)
+BOOST_AUTO_TEST_SUITE(Keybindings)
 
   BOOST_AUTO_TEST_CASE(loading_keybindings)
   {
@@ -54,6 +55,8 @@ BOOST_AUTO_TEST_SUITE(Theme)
 
       ustring final_cmd = ustring::compose (cmd, test_thread);
       log << test << "key: would run: " << final_cmd << endl;
+
+      Cmd("test", final_cmd).run ();
 
       return true;
     };

--- a/test/test_keybindings.cc
+++ b/test/test_keybindings.cc
@@ -1,0 +1,52 @@
+# define BOOST_TEST_DYN_LINK
+# define BOOST_TEST_MODULE TestKeybindings
+# include <boost/test/unit_test.hpp>
+
+# include "test_common.hh"
+# include "glibmm.h"
+
+# include "modes/keybindings.hh"
+
+using namespace std;
+using Astroid::ustring;
+
+
+BOOST_AUTO_TEST_SUITE(Theme)
+
+  BOOST_AUTO_TEST_CASE(loading_keybindings)
+  {
+    using namespace Astroid;
+    setup ();
+
+    Astroid::Keybindings::init ();
+
+    Astroid::Keybindings keys;
+    keys.set_prefix ("Test", "test");
+
+    keys.register_key ("a", "test.a", "A", [&] (Key) { return true; });
+
+    BOOST_CHECK_THROW (
+      keys.register_key ("b", "test.b", "B", [&] (Key) { return true; }),
+      duplicatekey_error);
+
+
+    keys.register_key (UnboundKey (), "test.unbound", "U1", [&] (Key) { return true; });
+    keys.register_key (UnboundKey (), "test.unbound2", "U2", [&] (Key) { return true; });
+
+    /* check a bad key spec */
+    BOOST_CHECK_THROW (
+      keys.register_key ("1-a", "test.k", "bad keyspec", [&] (Key) { return true; }),
+      keyspec_error);
+
+
+    /* check for duplicate when defining */
+    BOOST_CHECK_THROW (
+      keys.register_key ("a", "test.a", "duplicate keyspec", [&] (Key) { return true; }),
+      duplicatekey_error);
+
+    teardown ();
+  }
+
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
This implements #29 and allows custom shell commands to be bound to keys in astroid. For now there is only `thread_index.run`. This allows you to have a shell command be run with the `thread` as an argument. 

The run-hooks are configured through the keybindings file, the most rudimentary example which allows you to safely get the hang of it is to add a line like:

~/.config/astroid/keybindings:
```
thread_index.run(echo %1)=w
```

if you press `w` in the Thread Index the command `echo %1` will be run with `%1` replaced with the `thread`-id from the currently selected thread. 

A more useful example is to set up keybindings to toggle custom tags, first create a script that can toggle its given tag. In this example the `queue` tag:

~/.config/astroid/hooks/toggle (you can place this anywhere):
```sh
#! /usr/bin/bash
#
# get a tag as first argument and thread id as second argument
#

# check if we have tag
if [[ $(notmuch search thread:$2 and tag:$1) ]]; then
  echo "removing tag: $1 from thread:$2"
  notmuch tag -$1 thread:$2
else
  echo "adding tag: $1 from thread:$2"
  notmuch tag +$1 thread:$2
fi
``` 

then create a keybinding in:
~/.config/astroid/keybindings:
```sh
# toggle queue
thread_index.run(/home/gaute/.config/astroid/hooks/toggle queue %1)=w

# toggle todo
thread_index.run(/home/gaute/.config/astroid/hooks/toggle todo %1)=M-t
```

you can add several lines for different tags. A successful exit status (0) will trigger a refresh of the thread in astroid ensuring it is updated in all thread indexes. The command is passed to: [`Glib::spawn_command_line_sync`](https://developer.gnome.org/glibmm/stable/group__Spawn.html#ga75961831b4dd3979bb8ab508ee3b3de7). The argument (`thread`-id) is substituted into the string with [`ustring::compose()`](https://developer.gnome.org/glibmm/stable/classGlib_1_1ustring.html#a18e1242bc0ad8a961a28fb2198392258). Future run-hooks for other context may use more arguments, or substitute a list of `thread`-ids into the placeholder.

It would be nice to provide a way to reverse/undo the action. Perhaps being able to register a run-hook for the reverse or provide a flag for the reverse action.