### PR TITLE
ti: use state-less queries: load all threads in the background

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -13,6 +13,7 @@
 * Gravatar is configurable.
 * #103: Drafts are saved on force close or quit by default.
 * C-v: duplicate and refine query.
+* Use state-less queries in thread-index
 
 == v0.5 / 2016-02-06
 

--- a/History.txt
+++ b/History.txt
@@ -14,6 +14,9 @@
 * #103: Drafts are saved on force close or quit by default.
 * C-v: duplicate and refine query.
 * Use state-less queries in thread-index
+* All DB write-operations run in the background and wait for any
+  reads to finish first. Reducing chances of changes happening to the DB
+  while it is read, without blocking the UI.
 
 == v0.5 / 2016-02-06
 

--- a/SConstruct
+++ b/SConstruct
@@ -194,7 +194,7 @@ if conf.CheckNotmuchGetRev ():
   env.AppendUnique (CPPFLAGS = [ '-DHAVE_NOTMUCH_GET_REV' ])
 else:
   have_get_rev = False
-  print "notmuch_database_get_revision() not available. notmuch with lastmod capabilities will result in smoother polls."
+  print "notmuch_database_get_revision() not available. A recent notmuch with lastmod capabilities will result in easier updating of new threads and smoother polls."
 
 # external libraries
 env.ParseConfig ('pkg-config --libs --cflags glibmm-2.4')

--- a/src/actions/action.hh
+++ b/src/actions/action.hh
@@ -12,6 +12,10 @@ namespace Astroid {
       virtual bool undo (Db *) = 0;
       virtual bool undoable ();
 
+      /* used when undoing, the action_worker will undo the action
+       * without adding it to the doneactions */
+      bool in_undo = false;
+
       virtual void emit (Db *) = 0;
   };
 }

--- a/src/actions/action.hh
+++ b/src/actions/action.hh
@@ -16,6 +16,9 @@ namespace Astroid {
        * without adding it to the doneactions */
       bool in_undo = false;
 
+      /* generally actions need a read-write db */
+      bool needrwdb = true;
+
       virtual void emit (Db *) = 0;
   };
 }

--- a/src/actions/action.hh
+++ b/src/actions/action.hh
@@ -17,7 +17,8 @@ namespace Astroid {
       bool in_undo = false;
 
       /* generally actions need a read-write db */
-      bool needrwdb = true;
+      bool need_db    = true; /* only this will give ro-db */
+      bool need_db_rw = true; /* only this will lock db-rw */
 
       virtual void emit (Db *) = 0;
   };

--- a/src/actions/action_manager.cc
+++ b/src/actions/action_manager.cc
@@ -23,6 +23,10 @@ namespace Astroid {
       std::unique_lock<std::mutex> lk (actions_m);
       actions_cv.wait (lk, [&] { return !actions.empty (); });
 
+      /* lock emitter now, so that it does not start opening a
+       * read-only db while the read-write db is open */
+      lock_guard<std::mutex> elk (toemit_m);
+
       /* allow new actions to be queued while waiting for db */
       lk.unlock ();
 
@@ -44,7 +48,6 @@ namespace Astroid {
           doneactions.push_back (a);
         }
 
-        lock_guard<std::mutex> elk (toemit_m);
         toemit.push (a);
       }
 

--- a/src/actions/action_manager.cc
+++ b/src/actions/action_manager.cc
@@ -11,83 +11,147 @@
 using namespace std;
 
 namespace Astroid {
-  ActionManager::ActionManager () {
-
+  void ActionManager::doit (refptr<Action> action) {
+    std::lock_guard<std::mutex> lk (actions_m);
+    actions.push_back (action);
+    actions_cv.notify_one ();
   }
 
-  bool ActionManager::doit (Db * db, refptr<Action> action) {
-    if (action->undoable()) {
-      actions.push_back (action);
-    }
+  void ActionManager::action_worker () {
 
-    bool res = action->doit (db);
+    while (run) {
+      std::unique_lock<std::mutex> lk (actions_m);
+      actions_cv.wait (lk, [&] { return !actions.empty (); });
 
-    action->emit (db);
+      /* allow new actions to be queued while waiting for db */
+      lk.unlock ();
 
-    return res;
-  }
-
-  bool ActionManager::undo () {
-    log << info << "actions: undo" << endl;
-    if (!actions.empty ()) {
-      refptr<Action> action = actions.back ();
-      actions.pop_back ();
       Db db (Db::DbMode::DATABASE_READ_WRITE);
-      lock_guard<Db> grd (db);
 
-      bool res = action->undo (&db);
+      lk.lock ();
 
-      action->emit (&db);
+      while (!actions.empty ()) {
+        refptr<Action> a = actions.front ();
+        actions.pop_front ();
 
-      return res;
-    } else {
-      log << info << "actions: no more actions to undo." << endl;
-      return true;
+        if (!a->in_undo) {
+          a->doit (&db);
+        } else {
+          a->undo (&db);
+        }
+
+        if (!a->in_undo && a->undoable ()) {
+          doneactions.push_back (a);
+        }
+
+        lock_guard<std::mutex> elk (toemit_m);
+        toemit.push (a);
+      }
+
+      db.close ();
+      lk.unlock ();
+
+      emit_ready ();
     }
   }
 
-  GlobalActions::GlobalActions () {
+  void ActionManager::undo () {
+    log << info << "actions: undo" << endl;
+    std::lock_guard<std::mutex> lk (actions_m);
+
+    if (!actions.empty ()) {
+      log << info << "actions: action still in queue, removing.." << endl;
+
+      /* get last action queued and remove before it is done */
+      refptr<Action> a = actions.back ();
+      if (!a->in_undo) actions.pop_back ();
+
+      /* just ignore the undo if the previous undo is not finished yet */
+      return;
+
+    } else {
+      if (doneactions.empty ()) {
+        log << "actions: no more actions to undo." << endl;
+        return;
+      }
+
+      log << info << "actions: undoing already processed actions.." << endl;
+
+      /* get last action added and undo it */
+      refptr<Action> a = doneactions.back ();
+      doneactions.pop_back ();
+
+      a->in_undo = true;
+      doit (a); // queue for undo
+    }
+  }
+
+  void ActionManager::emitter () {
+    /* runs on gui thread */
+    std::lock_guard<std::mutex> lk (toemit_m);
+    Db db (Db::DATABASE_READ_ONLY);
+    while (!toemit.empty ()) {
+      refptr<Action> a = toemit.front ();
+      toemit.pop ();
+
+      a->emit (&db);
+    }
+  }
+
+  ActionManager::ActionManager () {
     log << info << "global actions: set up." << endl;
 
     /* set up GUI thread dispatcher for out-of-thread
      * signals */
     signal_refreshed_dispatcher.connect (
         sigc::mem_fun (this,
-          &GlobalActions::emit_refreshed));
+          &ActionManager::emit_refreshed));
+
+    emit_ready.connect (
+        sigc::mem_fun (this,
+          &ActionManager::emitter));
+
+    run = true;
+    action_worker_t = std::thread (&ActionManager::action_worker, this);
+  }
+
+  ActionManager::~ActionManager () {
+    run = false;
+    action_worker_t.join ();
   }
 
   /* signals */
-  GlobalActions::type_signal_thread_updated
-    GlobalActions::signal_thread_updated ()
+  ActionManager::type_signal_thread_updated
+    ActionManager::signal_thread_updated ()
   {
     return m_signal_thread_updated;
   }
 
-  void GlobalActions::emit_thread_updated (Db * db, ustring thread_id) {
+  void ActionManager::emit_thread_updated (Db * db, ustring thread_id) {
     log << info << "actions: emitted updated and changed signal for thread: " << thread_id << endl;
     m_signal_thread_updated.emit (db, thread_id);
     m_signal_thread_changed.emit (db, thread_id);
   }
 
-  GlobalActions::type_signal_thread_changed
-    GlobalActions::signal_thread_changed ()
+  ActionManager::type_signal_thread_changed
+    ActionManager::signal_thread_changed ()
   {
     return m_signal_thread_changed;
   }
 
-  void GlobalActions::emit_thread_changed (Db * db, ustring thread_id) {
+  void ActionManager::emit_thread_changed (Db * db, ustring thread_id) {
     log << info << "actions: emitted changed signal for thread: " << thread_id << endl;
     m_signal_thread_changed.emit (db, thread_id);
   }
 
   /* message */
-  GlobalActions::type_signal_message_updated
-    GlobalActions::signal_message_updated ()
+  ActionManager::type_signal_message_updated
+    ActionManager::signal_message_updated ()
   {
     return m_signal_message_updated;
   }
 
-  void GlobalActions::emit_message_updated (Db * db, ustring message_id) {
+  void ActionManager::emit_message_updated (Db * db, ustring message_id) {
     log << info << "actions: emitted updated signal for message: " << message_id << endl;
     m_signal_message_updated.emit (db, message_id);
 
@@ -105,13 +169,13 @@ namespace Astroid {
   }
 
   /* refreshed */
-  GlobalActions::type_signal_refreshed
-    GlobalActions::signal_refreshed ()
+  ActionManager::type_signal_refreshed
+    ActionManager::signal_refreshed ()
   {
     return m_signal_refreshed;
   }
 
-  void GlobalActions::emit_refreshed () {
+  void ActionManager::emit_refreshed () {
     log << info << "actions: emitted refreshed signal." << endl;
     m_signal_refreshed.emit ();
   }

--- a/src/actions/action_manager.cc
+++ b/src/actions/action_manager.cc
@@ -36,6 +36,7 @@ namespace Astroid {
         lk.unlock ();
 
         Db * db;
+        std::unique_lock<std::mutex> rw_lock;
 
         if (a->need_db) {
           if (a->need_db_rw) {
@@ -47,7 +48,7 @@ namespace Astroid {
           }
         } else {
           if (a->need_db_rw) {
-            Db::acquire_rw_lock ();
+            rw_lock = Db::acquire_rw_lock ();
             db = NULL;
           } else {
             Db::acquire_ro_lock ();
@@ -68,7 +69,7 @@ namespace Astroid {
           delete db;
         } else {
           if (a->need_db_rw) {
-            Db::release_rw_lock ();
+            Db::release_rw_lock (rw_lock);
           } else {
             Db::release_ro_lock ();
           }

--- a/src/actions/action_manager.cc
+++ b/src/actions/action_manager.cc
@@ -90,7 +90,7 @@ namespace Astroid {
 
   void ActionManager::undo () {
     log << info << "actions: undo" << endl;
-    std::lock_guard<std::mutex> lk (actions_m);
+    std::unique_lock<std::mutex> lk (actions_m);
 
     if (!actions.empty ()) {
       log << info << "actions: action still in queue, removing.." << endl;
@@ -115,6 +115,8 @@ namespace Astroid {
       doneactions.pop_back ();
 
       a->in_undo = true;
+
+      lk.unlock ();
       doit (a); // queue for undo
     }
   }

--- a/src/actions/cmdaction.cc
+++ b/src/actions/cmdaction.cc
@@ -7,7 +7,8 @@ namespace Astroid {
     cmd = _c;
     thread_id = _tid;
     mid = _mid;
-    needrwdb = false;
+    need_db    = false;
+    need_db_rw = true;
   }
 
   bool CmdAction::doit (Db *) {

--- a/src/actions/cmdaction.cc
+++ b/src/actions/cmdaction.cc
@@ -1,0 +1,35 @@
+# include "astroid.hh"
+# include "action_manager.hh"
+# include "cmdaction.hh"
+
+namespace Astroid {
+  CmdAction::CmdAction (Cmd _c, ustring _tid, ustring _mid) {
+    cmd = _c;
+    thread_id = _tid;
+    mid = _mid;
+    needrwdb = false;
+  }
+
+  bool CmdAction::doit (Db *) {
+    return cmd.run ();
+  }
+
+  bool CmdAction::undo (Db *) {
+    return false;
+  }
+
+  bool CmdAction::undoable () {
+    return false;
+  }
+
+  void CmdAction::emit (Db * db) {
+    if (thread_id != "") {
+      astroid->actions->emit_thread_updated (db, thread_id);
+    }
+
+    if (mid != "") {
+      astroid->actions->emit_message_updated (db, mid);
+    }
+  }
+}
+

--- a/src/actions/cmdaction.hh
+++ b/src/actions/cmdaction.hh
@@ -1,0 +1,23 @@
+# pragma once
+
+# include "action.hh"
+# include "utils/cmd.hh"
+
+namespace Astroid {
+  class CmdAction : public Action {
+    public:
+      CmdAction (Cmd c, ustring thread_id, ustring mid);
+
+
+      virtual bool doit (Db *) override;
+      virtual bool undo (Db *) override;
+      virtual bool undoable () override;
+      virtual void emit (Db *) override;
+
+    private:
+      Cmd cmd;
+      ustring thread_id;
+      ustring mid;
+
+  };
+}

--- a/src/actions/onmessage.cc
+++ b/src/actions/onmessage.cc
@@ -1,0 +1,83 @@
+# include <functional>
+# include <vector>
+
+# include <notmuch.h>
+
+# include "onmessage.hh"
+# include "db.hh"
+# include "action_manager.hh"
+# include "astroid.hh"
+
+namespace Astroid {
+  OnMessageAction::OnMessageAction (
+      ustring _msg_id,
+      std::function <void(Db *, notmuch_message_t *)> _b) {
+
+    msg_id  = _msg_id;
+    block   = _b;
+  }
+
+  bool OnMessageAction::doit (Db * db) {
+    db->on_message (msg_id, std::bind (block, db, std::placeholders::_1));
+    return true;
+  }
+
+  bool OnMessageAction::undo (Db *) {
+    return false;
+  }
+
+  bool OnMessageAction::undoable () {
+    return false;
+  }
+
+  void OnMessageAction::emit (Db * db) {
+    astroid->actions->emit_message_updated (db, msg_id);
+  }
+
+
+  AddDraftMessage::AddDraftMessage (ustring _f) {
+    fname = _f;
+  }
+
+  bool AddDraftMessage::doit (Db * db) {
+    mid = db->add_draft_message (fname);
+    return true;
+  }
+
+  bool AddDraftMessage::undo (Db *) {
+    return false;
+  }
+
+  bool AddDraftMessage::undoable () {
+    return false;
+  }
+
+  void AddDraftMessage::emit (Db * db) {
+    if (mid != "")
+      astroid->actions->emit_message_updated (db, mid);
+  }
+
+  AddSentMessage::AddSentMessage (ustring _f, std::vector<ustring> _additional_sent_tags) {
+    fname = _f;
+    additional_sent_tags = _additional_sent_tags;
+  }
+
+  bool AddSentMessage::doit (Db * db) {
+    mid = db->add_sent_message (fname, additional_sent_tags);
+    return true;
+  }
+
+  bool AddSentMessage::undo (Db *) {
+    return false;
+  }
+
+  bool AddSentMessage::undoable () {
+    return false;
+  }
+
+  void AddSentMessage::emit (Db * db) {
+    if (mid != "")
+      astroid->actions->emit_message_updated (db, mid);
+  }
+}
+

--- a/src/actions/onmessage.hh
+++ b/src/actions/onmessage.hh
@@ -1,0 +1,56 @@
+# pragma once
+
+# include <vector>
+# include <functional>
+
+# include <notmuch.h>
+
+# include "proto.hh"
+# include "action.hh"
+
+namespace Astroid {
+  class OnMessageAction : public Action {
+    public:
+      OnMessageAction (ustring msg_id, std::function <void(Db *, notmuch_message_t *)>);
+
+      virtual bool doit (Db *) override;
+      virtual bool undo (Db *) override;
+      virtual bool undoable () override;
+      virtual void emit (Db *) override;
+
+    private:
+      ustring msg_id;
+      std::function <void(Db *, notmuch_message_t *)> block;
+
+  };
+
+  class AddDraftMessage : public Action {
+    public:
+      AddDraftMessage (ustring fname);
+
+      virtual bool doit (Db *) override;
+      virtual bool undo (Db *) override;
+      virtual bool undoable () override;
+      virtual void emit (Db *) override;
+
+    private:
+      ustring fname;
+      ustring mid;
+  };
+
+  class AddSentMessage : public Action {
+    public:
+      AddSentMessage (ustring fname, std::vector<ustring> additional_sent_tags);
+
+      virtual bool doit (Db *) override;
+      virtual bool undo (Db *) override;
+      virtual bool undoable () override;
+      virtual void emit (Db *) override;
+
+    private:
+      ustring fname;
+      ustring mid;
+      std::vector<ustring> additional_sent_tags;
+  };
+
+}

--- a/src/astroid.cc
+++ b/src/astroid.cc
@@ -15,6 +15,7 @@
 # include "config.hh"
 # include "account_manager.hh"
 # include "actions/action_manager.hh"
+# include "actions/action.hh"
 # include "utils/date_utils.hh"
 # include "log.hh"
 # include "poll.hh"
@@ -216,7 +217,7 @@ namespace Astroid {
     //contacts = new Contacts ();
 
     /* set up global actions */
-    global_actions = new GlobalActions ();
+    actions = new ActionManager ();
 
     /* set up poller */
     poll = new Poll (!no_auto_poll);
@@ -257,7 +258,7 @@ namespace Astroid {
     //contacts = new Contacts ();
 
     /* set up global actions */
-    global_actions = new GlobalActions ();
+    actions = new ActionManager ();
 
     /* set up poller */
     poll = new Poll (false);
@@ -273,7 +274,7 @@ namespace Astroid {
     //if (contacts != NULL) delete contacts;
     delete m_config;
     delete poll;
-    delete global_actions;
+    delete actions;
 
     log << info << "astroid: goodbye!" << endl;
     log.del_out_stream (&cout);

--- a/src/astroid.hh
+++ b/src/astroid.hh
@@ -35,7 +35,7 @@ namespace Astroid {
       //Contacts * contacts;
 
       /* actions */
-      GlobalActions * global_actions;
+      ActionManager * actions;
 
       /* poll */
       Poll * poll;

--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -14,6 +14,8 @@
 # include "account_manager.hh"
 # include "log.hh"
 # include "chunk.hh"
+# include "actions/action_manager.hh"
+# include "actions/onmessage.hh"
 
 using namespace std;
 namespace bfs = boost::filesystem;
@@ -298,8 +300,8 @@ namespace Astroid {
   void ComposeMessage::message_sent_event () {
     /* add to notmuch with sent tag (on main GUI thread) */
     if (!dryrun && message_sent_result && account->save_sent) {
-      Db db (Db::DbMode::DATABASE_READ_WRITE);
-      db.add_sent_message (save_to.c_str(), account->additional_sent_tags);
+      astroid->actions->doit (refptr<Action> (
+            new AddSentMessage (save_to.c_str (), account->additional_sent_tags)));
       log << info << "cm: sent message added to db." << endl;
     }
 

--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -299,7 +299,6 @@ namespace Astroid {
     /* add to notmuch with sent tag (on main GUI thread) */
     if (!dryrun && message_sent_result && account->save_sent) {
       Db db (Db::DbMode::DATABASE_READ_WRITE);
-      lock_guard<Db> lk (db);
       db.add_sent_message (save_to.c_str(), account->additional_sent_tags);
       log << info << "cm: sent message added to db." << endl;
     }

--- a/src/config.cc
+++ b/src/config.cc
@@ -136,9 +136,10 @@ namespace Astroid {
       default_config.put("startup.queries.inbox", "tag:inbox");
     }
 
-    /* ui behaviour */
+    /* thread index */
     default_config.put ("thread_index.page_jump_rows", 6);
     default_config.put ("thread_index.sort_order", "newest");
+    default_config.put ("thread_index.thread_load_step", 250);
 
     default_config.put ("general.time.clock_format", "local"); // or 24h, 12h
     default_config.put ("general.time.same_year", "%b %-e");

--- a/src/db.cc
+++ b/src/db.cc
@@ -70,7 +70,7 @@ namespace Astroid {
     sort (sent_tags.begin (), sent_tags.end ());
   }
 
-  void Db::close_db () {
+  void Db::close () {
     if (nm_db != NULL) {
       log << info << "db: closing db." << endl;
       notmuch_database_close (nm_db);
@@ -81,7 +81,7 @@ namespace Astroid {
 
   bool Db::open_db_write (bool block) {
     log << info << "db: open db read-write." << endl;
-    close_db ();
+    close ();
     db_state = IN_CHANGE;
 
     notmuch_status_t s;
@@ -128,7 +128,7 @@ namespace Astroid {
 
   bool Db::open_db_read_only () {
     log << info << "db: open db read-only." << endl;
-    close_db ();
+    close ();
 
     db_state = IN_CHANGE;
 
@@ -153,7 +153,7 @@ namespace Astroid {
   }
 
   Db::~Db () {
-    close_db ();
+    close ();
   }
 
 # ifdef HAVE_NOTMUCH_GET_REV
@@ -207,7 +207,7 @@ namespace Astroid {
 
     /* emit signal */
     if (tid != "") {
-      astroid->global_actions->emit_thread_updated (this, tid);
+      astroid->actions->emit_thread_updated (this, tid);
     }
   }
 
@@ -237,7 +237,7 @@ namespace Astroid {
     /* emit signal */
     const char * mid = notmuch_message_get_message_id (msg);
     if (mid != NULL) {
-      astroid->global_actions->emit_message_updated (this, ustring (mid));
+      astroid->actions->emit_message_updated (this, ustring (mid));
     }
 
     notmuch_message_destroy (msg);
@@ -712,7 +712,7 @@ namespace Astroid {
 
 
   void NotmuchThread::emit_updated (Db * db) {
-    astroid->global_actions->emit_thread_updated (db, thread_id);
+    astroid->actions->emit_thread_updated (db, thread_id);
   }
 
   ustring NotmuchThread::str () {
@@ -813,7 +813,7 @@ namespace Astroid {
   }
 
   void NotmuchMessage::emit_updated (Db * db) {
-    astroid->global_actions->emit_message_updated (db, mid);
+    astroid->actions->emit_message_updated (db, mid);
   }
 
   ustring NotmuchMessage::str () {

--- a/src/db.cc
+++ b/src/db.cc
@@ -500,6 +500,8 @@ namespace Astroid {
   }
 
   vector<tuple<ustring,bool>> NotmuchThread::get_authors (notmuch_thread_t * nm_thread) {
+    /* important: this might be called from another thread, we cannot output anything here */
+
     /* returns a vector of authors and whether they are authors of
      * an unread message in the thread */
     vector<tuple<ustring, bool>> aths;
@@ -517,7 +519,7 @@ namespace Astroid {
       if (auths != NULL) {
         astr = auths;
       } else {
-        log << error << "nmt: got NULL for authors!" << endl;
+        /* log << error << "nmt: got NULL for authors!" << endl; */
       }
 
       std::vector<ustring> maths = VectorUtils::split_and_trim (astr, ",|\\|");
@@ -546,7 +548,7 @@ namespace Astroid {
       if (ac != NULL) {
         a = Address(ustring (ac)).fail_safe_name ();
       } else {
-        log << error << "nmt: got NULL for author!" << endl;
+        /* log << error << "nmt: got NULL for author!" << endl; */
         continue;
       }
 

--- a/src/db.cc
+++ b/src/db.cc
@@ -437,7 +437,6 @@ namespace Astroid {
   void NotmuchThread::refresh (Db * db) {
     /* do a new db query and update all fields */
 
-    lock_guard <Db> grd (*db);
     db->on_thread (thread_id,
         [&](notmuch_thread_t * nm_thread) {
 
@@ -597,8 +596,6 @@ namespace Astroid {
 
   /* tag actions */
   bool NotmuchThread::add_tag (Db * db, ustring tag) {
-    lock_guard <Db> grd (*db);
-
     log << debug << "nm (" << thread_id << "): add tag: " << tag << endl;
     tag = Db::sanitize_tag (tag);
     if (!Db::check_tag (tag)) {
@@ -729,8 +726,6 @@ namespace Astroid {
 
   /* tag actions */
   bool NotmuchMessage::add_tag (Db * db, ustring tag) {
-    lock_guard <Db> grd (*db);
-
     log << debug << "nm (" << mid << "): add tag: " << tag << endl;
     tag = Db::sanitize_tag (tag);
     if (!Db::check_tag (tag)) {
@@ -771,8 +766,6 @@ namespace Astroid {
   }
 
   bool NotmuchMessage::remove_tag (Db * db, ustring tag) {
-    lock_guard <Db> grd (*db);
-
     log << debug << "nm (" << mid << "): remove tag: " << tag << endl;
     tag = Db::sanitize_tag (tag);
     if (!Db::check_tag (tag)) {

--- a/src/db.hh
+++ b/src/db.hh
@@ -126,6 +126,8 @@ namespace Astroid {
       const int db_write_open_timeout = 30; // seconds
       const int db_write_open_delay   = 1; // seconds
 
+      static bool settings_loaded;
+
     public:
       notmuch_database_t * nm_db;
 
@@ -134,13 +136,13 @@ namespace Astroid {
       void load_tags ();
       void test_query ();
 
-      std::vector<ustring> sent_tags = { "sent" };
-      std::vector<ustring> draft_tags = { "draft" };
-      std::vector<ustring> excluded_tags = { "muted", "spam", "deleted" };
+      static std::vector<ustring> sent_tags;
+      static std::vector<ustring> draft_tags;
+      static std::vector<ustring> excluded_tags;
 
-      void add_sent_message (ustring, std::vector<ustring>);
-      void add_draft_message (ustring);
-      void add_message_with_tags (ustring fname, std::vector<ustring> tags);
+      ustring add_sent_message (ustring, std::vector<ustring>);
+      ustring add_draft_message (ustring);
+      ustring add_message_with_tags (ustring fname, std::vector<ustring> tags);
       void remove_message (ustring);
 
       static ustring sanitize_tag (ustring);

--- a/src/db.hh
+++ b/src/db.hh
@@ -115,8 +115,8 @@ namespace Astroid {
 
       /* lock db: use if you need the db in external program and need
        * a specific lock */
-      static void acquire_rw_lock ();
-      static void release_rw_lock ();
+      static std::unique_lock<std::mutex> acquire_rw_lock ();
+      static void release_rw_lock (std::unique_lock<std::mutex> &);
 
       static void acquire_ro_lock ();
       static void release_ro_lock ();
@@ -142,7 +142,6 @@ namespace Astroid {
       /* notify when read_only_dbs change */
       static std::condition_variable  dbs_open;
       std::unique_lock<std::mutex>    rw_lock;
-      static std::unique_lock<std::mutex> rw_lock_s; // used by static locker
 
       DbMode mode;
 

--- a/src/db.hh
+++ b/src/db.hh
@@ -73,7 +73,7 @@ namespace Astroid {
       std::vector<ustring> get_tags (notmuch_thread_t *);
   };
 
-  class Db : public std::recursive_mutex {
+  class Db {
     public:
       enum DbMode {
         DATABASE_READ_ONLY,

--- a/src/db.hh
+++ b/src/db.hh
@@ -94,6 +94,33 @@ namespace Astroid {
       unsigned long get_revision ();
 # endif
 
+      notmuch_database_t * nm_db;
+
+      std::vector<ustring> tags;
+
+      void load_tags ();
+      void test_query ();
+
+      static std::vector<ustring> sent_tags;
+      static std::vector<ustring> draft_tags;
+      static std::vector<ustring> excluded_tags;
+
+      ustring add_sent_message (ustring, std::vector<ustring>);
+      ustring add_draft_message (ustring);
+      ustring add_message_with_tags (ustring fname, std::vector<ustring> tags);
+      void remove_message (ustring);
+
+      static ustring sanitize_tag (ustring);
+      static bool check_tag (ustring);
+
+      /* lock db: use if you need the db in external program and need
+       * a specific lock */
+      static void acquire_rw_lock ();
+      static void release_rw_lock ();
+
+      static void acquire_ro_lock ();
+      static void release_ro_lock ();
+
     private:
       /* we can have as many read-only db's open as we want, but only one
        * read-write at the same time. there can also not be any other
@@ -115,6 +142,7 @@ namespace Astroid {
       /* notify when read_only_dbs change */
       static std::condition_variable  dbs_open;
       std::unique_lock<std::mutex>    rw_lock;
+      static std::unique_lock<std::mutex> rw_lock_s; // used by static locker
 
       DbMode mode;
 
@@ -127,26 +155,6 @@ namespace Astroid {
       const int db_write_open_delay   = 1; // seconds
 
       static bool settings_loaded;
-
-    public:
-      notmuch_database_t * nm_db;
-
-      std::vector<ustring> tags;
-
-      void load_tags ();
-      void test_query ();
-
-      static std::vector<ustring> sent_tags;
-      static std::vector<ustring> draft_tags;
-      static std::vector<ustring> excluded_tags;
-
-      ustring add_sent_message (ustring, std::vector<ustring>);
-      ustring add_draft_message (ustring);
-      ustring add_message_with_tags (ustring fname, std::vector<ustring> tags);
-      void remove_message (ustring);
-
-      static ustring sanitize_tag (ustring);
-      static bool check_tag (ustring);
   };
 
   /* exceptions */

--- a/src/db.hh
+++ b/src/db.hh
@@ -83,9 +83,6 @@ namespace Astroid {
       Db (DbMode = DATABASE_READ_ONLY);
       ~Db ();
 
-      void reopen ();
-      bool check_reopen (bool);
-
       void on_thread  (ustring, std::function <void(notmuch_thread_t *)>);
       void on_message (ustring, std::function <void(notmuch_message_t *)>);
 

--- a/src/db.hh
+++ b/src/db.hh
@@ -82,6 +82,7 @@ namespace Astroid {
 
       Db (DbMode = DATABASE_READ_ONLY);
       ~Db ();
+      void close ();
 
       void on_thread  (ustring, std::function <void(notmuch_thread_t *)>);
       void on_message (ustring, std::function <void(notmuch_message_t *)>);
@@ -105,7 +106,6 @@ namespace Astroid {
 
       bool open_db_write (bool);
       bool open_db_read_only ();
-      void close_db ();
 
       bfs::path path_db;
       const int db_write_open_timeout = 30; // seconds

--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -60,6 +60,8 @@ namespace Astroid {
   MainWindow::MainWindow () {
     id = ++nextid;
 
+    actions = astroid->actions;
+
     log << debug << "mw: init, id: " << id << endl;
 
     set_title ("");
@@ -247,7 +249,7 @@ namespace Astroid {
     keys.register_key ("u", "main_window.undo",
         "Undo last action",
         [&] (Key) {
-          actions.undo ();
+          actions->undo ();
           return true;
         });
 

--- a/src/main_window.hh
+++ b/src/main_window.hh
@@ -51,7 +51,7 @@ namespace Astroid {
       void on_command_mode_changed ();
 
       /* actions */
-      ActionManager actions;
+      ActionManager * actions;
 
       int current = -1;
       bool active = false;

--- a/src/message_thread.cc
+++ b/src/message_thread.cc
@@ -29,7 +29,7 @@ namespace Astroid {
     has_file   = false;
     missing_content = false;
 
-    astroid->global_actions->signal_message_updated ().connect (
+    astroid->actions->signal_message_updated ().connect (
         sigc::mem_fun (this, &Message::on_message_updated));
   }
 

--- a/src/message_thread.cc
+++ b/src/message_thread.cc
@@ -112,7 +112,6 @@ namespace Astroid {
     } else {
       /* get tags from nm db */
 
-      lock_guard<Db> grd (*db);
       db->on_message (mid, [&](notmuch_message_t * msg)
         {
           load_tags (msg);

--- a/src/modes/edit_message.cc
+++ b/src/modes/edit_message.cc
@@ -405,7 +405,6 @@ namespace Astroid {
 
     if (add_to_notmuch) {
       Db db (Db::DbMode::DATABASE_READ_WRITE);
-      lock_guard<Db> lk (db);
       db.add_draft_message (fname);
     }
 
@@ -422,7 +421,6 @@ namespace Astroid {
         boost::filesystem::remove (fname);
 
         Db db (Db::DbMode::DATABASE_READ_WRITE);
-        lock_guard<Db> lk (db);
 
         /* first remove tag in case it has been sent */
         db.on_message (draft_msg->mid,

--- a/src/modes/forward_message.cc
+++ b/src/modes/forward_message.cc
@@ -116,7 +116,7 @@ namespace Astroid {
           });
 
 
-      astroid->global_actions->emit_message_updated (&db, msg->mid);
+      astroid->actions->emit_message_updated (&db, msg->mid);
     }
   }
 }

--- a/src/modes/forward_message.cc
+++ b/src/modes/forward_message.cc
@@ -8,6 +8,7 @@
 # include "forward_message.hh"
 
 # include "actions/action_manager.hh"
+# include "actions/onmessage.hh"
 
 # include "message_thread.hh"
 # include "utils/address.hh"
@@ -106,17 +107,14 @@ namespace Astroid {
         return;
       }
 
-      Db db(Db::DATABASE_READ_WRITE);
+      astroid->actions->doit (refptr<Action>(
+            new OnMessageAction (msg->mid,
 
-      db.on_message (msg->mid,
-          [&] (notmuch_message_t * nm_msg) {
+              [] (Db *, notmuch_message_t * msg) {
 
-            notmuch_message_add_tag (nm_msg, "passed");
+                notmuch_message_add_tag (msg, "passed");
 
-          });
-
-
-      astroid->actions->emit_message_updated (&db, msg->mid);
+              })));
     }
   }
 }

--- a/src/modes/reply_message.cc
+++ b/src/modes/reply_message.cc
@@ -220,7 +220,7 @@ namespace Astroid {
           });
 
 
-      astroid->global_actions->emit_message_updated (&db, msg->mid);
+      astroid->actions->emit_message_updated (&db, msg->mid);
     }
   }
 }

--- a/src/modes/reply_message.cc
+++ b/src/modes/reply_message.cc
@@ -7,6 +7,7 @@
 # include "reply_message.hh"
 
 # include "actions/action_manager.hh"
+# include "actions/onmessage.hh"
 
 # include "message_thread.hh"
 # include "utils/address.hh"
@@ -210,17 +211,14 @@ namespace Astroid {
         return;
       }
 
-      Db db(Db::DATABASE_READ_WRITE);
+      astroid->actions->doit (refptr<Action>(
+            new OnMessageAction (msg->mid,
 
-      db.on_message (msg->mid,
-          [&] (notmuch_message_t * nm_msg) {
+              [] (Db *, notmuch_message_t * msg) {
 
-            notmuch_message_add_tag (nm_msg, "replied");
+                notmuch_message_add_tag (msg, "replied");
 
-          });
-
-
-      astroid->actions->emit_message_updated (&db, msg->mid);
+              })));
     }
   }
 }

--- a/src/modes/thread_index/query_loader.cc
+++ b/src/modes/thread_index/query_loader.cc
@@ -269,7 +269,6 @@ namespace Astroid {
     }
 
     /* test if thread is in the current query */
-    std::lock_guard<Db> grd (*db);
     bool in_query = db->thread_in_query (query, thread_id);
 
     if (found) {

--- a/src/modes/thread_index/query_loader.cc
+++ b/src/modes/thread_index/query_loader.cc
@@ -58,6 +58,7 @@ namespace Astroid {
   }
 
   void QueryLoader::start (ustring q) {
+    std::lock_guard<std::mutex> lk (loader_m);
     query = q;
     run = true;
     loader_thread = std::thread (&QueryLoader::loader, this);
@@ -69,8 +70,13 @@ namespace Astroid {
   }
 
   void QueryLoader::reload () {
+    std::lock_guard<std::mutex> lk (to_list_m);
     stop ();
     list_store->clear ();
+
+    while (!to_list_store.empty ())
+      to_list_store.pop ();
+
     start (query);
   }
 

--- a/src/modes/thread_index/query_loader.cc
+++ b/src/modes/thread_index/query_loader.cc
@@ -44,10 +44,10 @@ namespace Astroid {
     queue_has_data.connect (
         sigc::mem_fun (this, &QueryLoader::to_list_adder));
 
-    astroid->global_actions->signal_thread_changed ().connect (
+    astroid->actions->signal_thread_changed ().connect (
         sigc::mem_fun (this, &QueryLoader::on_thread_changed));
 
-    astroid->global_actions->signal_refreshed ().connect (
+    astroid->actions->signal_refreshed ().connect (
         sigc::mem_fun (this, &QueryLoader::on_refreshed));
   }
 

--- a/src/modes/thread_index/query_loader.cc
+++ b/src/modes/thread_index/query_loader.cc
@@ -230,8 +230,6 @@ namespace Astroid {
 
     log << info << "ql (" << id << "): " << query << ", got changed thread signal: " << thread_id << endl;
 
-    std::lock_guard<std::mutex> loader_lk (loader_m);
-
     /* we now have three options:
      * - a new thread has been added (unlikely)
      * - a thread has been deleted (kind of likely)

--- a/src/modes/thread_index/query_loader.cc
+++ b/src/modes/thread_index/query_loader.cc
@@ -298,7 +298,7 @@ namespace Astroid {
 
         NotmuchThread * t;
 
-        db->on_thread (thread_id, [&](notmuch_thread_t *nmt) {
+        db->on_thread (thread_id, [&t](notmuch_thread_t *nmt) {
 
             t = new NotmuchThread (nmt);
 

--- a/src/modes/thread_index/query_loader.cc
+++ b/src/modes/thread_index/query_loader.cc
@@ -74,8 +74,8 @@ namespace Astroid {
   }
 
   void QueryLoader::reload () {
-    std::lock_guard<std::mutex> lk (to_list_m);
     stop ();
+    std::lock_guard<std::mutex> lk (to_list_m);
     list_store->clear ();
 
     while (!to_list_store.empty ())

--- a/src/modes/thread_index/query_loader.cc
+++ b/src/modes/thread_index/query_loader.cc
@@ -1,0 +1,162 @@
+# include "astroid.hh"
+# include "db.hh"
+# include "log.hh"
+
+# include "query_loader.hh"
+# include "thread_index_list_view.hh"
+# include "config.hh"
+
+# include <thread>
+# include <notmuch.h>
+
+using std::endl;
+
+namespace Astroid {
+  QueryLoader::QueryLoader () {
+    ustring sort_order = astroid->config ().get<std::string> ("thread_index.sort_order");
+    if (sort_order == "newest") {
+      sort = NOTMUCH_SORT_NEWEST_FIRST;
+    } else if (sort_order == "oldest") {
+      sort = NOTMUCH_SORT_OLDEST_FIRST;
+    } else if (sort_order == "messageid") {
+      sort = NOTMUCH_SORT_MESSAGE_ID;
+    } else if (sort_order == "unsorted") {
+      sort = NOTMUCH_SORT_UNSORTED;
+    } else {
+      log << error << "ti: unknown sort order, must be 'newest', 'oldest', 'messageid' or 'unsorted': " << sort_order << ", using 'newest'." << endl;
+      sort = NOTMUCH_SORT_NEWEST_FIRST;
+    }
+
+    loaded_threads = 0;
+    total_messages = 0;
+    unread_messages = 0;
+  }
+
+  QueryLoader::~QueryLoader () {
+    stop ();
+  }
+
+  void QueryLoader::start (ustring q) {
+    query = q;
+    run = true;
+    loader_thread = std::thread (&QueryLoader::loader, this);
+  }
+
+  void QueryLoader::stop () {
+    run = false;
+    loader_thread.join ();
+  }
+
+  void QueryLoader::reload () {
+    stop ();
+    list_store->clear ();
+    start (query);
+  }
+
+  void QueryLoader::refine_query (ustring q) {
+    query = q;
+    reload ();
+  }
+
+  void QueryLoader::refresh_stats (Db * db) {
+    log << debug << "ql: refresh stats.." << endl;
+
+    notmuch_query_t * query_t =  notmuch_query_create (db->nm_db, query.c_str ());
+    for (ustring & t : db->excluded_tags) {
+      notmuch_query_add_tag_exclude (query_t, t.c_str());
+    }
+    notmuch_query_set_omit_excluded (query_t, NOTMUCH_EXCLUDE_TRUE);
+    /* st = */ notmuch_query_count_messages_st (query_t, &total_messages); // destructive
+    notmuch_query_destroy (query_t);
+
+    ustring unread_q_s = "(" + query + ") AND tag:unread";
+    notmuch_query_t * unread_q = notmuch_query_create (db->nm_db, unread_q_s.c_str());
+    for (ustring & t : db->excluded_tags) {
+      notmuch_query_add_tag_exclude (unread_q, t.c_str());
+    }
+    notmuch_query_set_omit_excluded (unread_q, NOTMUCH_EXCLUDE_TRUE);
+    /* st = */ notmuch_query_count_messages_st (unread_q, &unread_messages); // destructive
+    notmuch_query_destroy (unread_q);
+
+    stats_ready.emit ();
+  }
+
+  void QueryLoader::loader () {
+    time_t t0 = clock ();
+
+    log << debug << "ql: load threads for query: " << query << endl;
+
+
+    Db db (Db::DATABASE_READ_ONLY);
+
+    /* set up query */
+    notmuch_query_t * nmquery;
+    notmuch_threads_t * threads;
+
+    nmquery = notmuch_query_create (db.nm_db, query.c_str ());
+    for (ustring & t : db.excluded_tags) {
+      notmuch_query_add_tag_exclude (nmquery, t.c_str());
+    }
+
+    notmuch_query_set_omit_excluded (nmquery, NOTMUCH_EXCLUDE_TRUE);
+    notmuch_query_set_sort (nmquery, sort);
+
+    /* slow */
+    /* notmuch_status_t st = */ notmuch_query_search_threads_st (nmquery, &threads);
+    float diff = (clock () - t0) * 1000.0 / CLOCKS_PER_SEC;
+
+    log << debug << "ql: query time: " << diff << " ms." << endl;
+
+    loaded_threads = 0;
+
+    for (;
+         run && notmuch_threads_valid (threads);
+         notmuch_threads_move_to_next (threads)) {
+
+      notmuch_thread_t  * thread;
+      thread = notmuch_threads_get (threads);
+
+      if (thread == NULL) {
+        log << error << "ql: error: could not get thread." << endl;
+        throw database_error ("ql: could not get thread (is NULL)");
+      }
+
+      NotmuchThread *t = new NotmuchThread (thread);
+
+      notmuch_thread_destroy (thread);
+
+      auto iter = list_store->append ();
+      Gtk::ListStore::Row row = *iter;
+
+      row[list_store->columns.newest_date] = t->newest_date;
+      row[list_store->columns.oldest_date] = t->oldest_date;
+      row[list_store->columns.thread_id]   = t->thread_id;
+      row[list_store->columns.thread]      = Glib::RefPtr<NotmuchThread>(t);
+
+      if (loaded_threads == 0) {
+        first_thread_ready.emit ();
+      }
+
+      loaded_threads++;
+
+      if ((loaded_threads % 100) == 0) {
+        log << debug << "ql: loaded " << loaded_threads << " threads." << endl;
+      }
+    }
+
+    /* closing query */
+    notmuch_threads_destroy (threads);
+    notmuch_query_destroy (nmquery);
+
+    refresh_stats (&db);
+
+    log << info << "ql: loaded " << loaded_threads << " threads in " << ((clock()-t0) * 1000.0 / CLOCKS_PER_SEC) << " ms." << endl;
+
+    if (!run) {
+      log << warn << "ql: stopped before finishing." << endl;
+    }
+
+    run = false;
+  }
+}
+

--- a/src/modes/thread_index/query_loader.hh
+++ b/src/modes/thread_index/query_loader.hh
@@ -1,6 +1,8 @@
 # pragma once
 
 # include <thread>
+# include <mutex>
+# include <queue>
 # include <notmuch.h>
 
 # include "proto.hh"
@@ -36,9 +38,16 @@ namespace Astroid {
       ustring query;
 
       bool run = false;
+      bool in_destructor = false;
       void loader ();
 
       std::thread loader_thread;
+
+      std::queue<refptr<NotmuchThread>> to_list_store;
+      std::mutex to_list_m;
+
+      void to_list_adder ();
+      Glib::Dispatcher queue_has_data;
 
   };
 }

--- a/src/modes/thread_index/query_loader.hh
+++ b/src/modes/thread_index/query_loader.hh
@@ -11,6 +11,9 @@
 namespace Astroid {
   class QueryLoader {
     public:
+      static int nextid;
+
+      int id;
       QueryLoader ();
       ~QueryLoader ();
 

--- a/src/modes/thread_index/query_loader.hh
+++ b/src/modes/thread_index/query_loader.hh
@@ -1,0 +1,45 @@
+# pragma once
+
+# include <thread>
+# include <notmuch.h>
+
+# include "proto.hh"
+# include "thread_index_list_view.hh"
+
+namespace Astroid {
+  class QueryLoader {
+    public:
+      QueryLoader ();
+      ~QueryLoader ();
+
+      void refine_query (ustring);
+
+      void start (ustring);
+      void stop ();
+      void reload ();
+
+      unsigned int loaded_threads;
+      unsigned int total_messages;
+      unsigned int unread_messages;
+
+      void refresh_stats (Db *);
+
+      refptr<ThreadIndexListStore> list_store;
+
+      notmuch_sort_t sort;
+      std::vector<ustring> sort_strings = { "oldest", "newest", "messageid", "unsorted" };
+
+      Glib::Dispatcher first_thread_ready;
+      Glib::Dispatcher stats_ready;
+
+    private:
+      ustring query;
+
+      bool run = false;
+      void loader ();
+
+      std::thread loader_thread;
+
+  };
+}
+

--- a/src/modes/thread_index/query_loader.hh
+++ b/src/modes/thread_index/query_loader.hh
@@ -9,7 +9,7 @@
 # include "thread_index_list_view.hh"
 
 namespace Astroid {
-  class QueryLoader {
+  class QueryLoader : public sigc::trackable {
     public:
       static int nextid;
 

--- a/src/modes/thread_index/query_loader.hh
+++ b/src/modes/thread_index/query_loader.hh
@@ -34,6 +34,7 @@ namespace Astroid {
       Glib::Dispatcher first_thread_ready;
       Glib::Dispatcher stats_ready;
 
+      bool loading ();
     private:
       ustring query;
 
@@ -42,6 +43,7 @@ namespace Astroid {
       void loader ();
 
       std::thread loader_thread;
+      std::mutex  loader_m;
 
       std::queue<refptr<NotmuchThread>> to_list_store;
       std::mutex to_list_m;
@@ -50,19 +52,6 @@ namespace Astroid {
       Glib::Dispatcher queue_has_data;
 
       /* signal handlers */
-
-      /*
-       * if the query is loading, defer these events
-       * untill the queue is loaded:
-       *
-       * to_list_adder () will check this queue when (run == false)
-       *
-       * (synchornization on this list should not be needed since both
-       *  on_thread_changed and to_list_adder are run on the main GUI
-       *  thread)
-       *
-       */
-      std::queue<ustring> thread_changed_events_waiting;
 
       void on_thread_changed (Db *, ustring);
       void on_refreshed ();

--- a/src/modes/thread_index/query_loader.hh
+++ b/src/modes/thread_index/query_loader.hh
@@ -37,7 +37,7 @@ namespace Astroid {
     private:
       ustring query;
 
-      bool run = false;
+      std::atomic<bool> run;
       bool in_destructor = false;
       void loader ();
 
@@ -49,6 +49,23 @@ namespace Astroid {
       void to_list_adder ();
       Glib::Dispatcher queue_has_data;
 
+      /* signal handlers */
+
+      /*
+       * if the query is loading, defer these events
+       * untill the queue is loaded:
+       *
+       * to_list_adder () will check this queue when (run == false)
+       *
+       * (synchornization on this list should not be needed since both
+       *  on_thread_changed and to_list_adder are run on the main GUI
+       *  thread)
+       *
+       */
+      std::queue<ustring> thread_changed_events_waiting;
+
+      void on_thread_changed (Db *, ustring);
+      void on_refreshed ();
   };
 }
 

--- a/src/modes/thread_index/thread_index.cc
+++ b/src/modes/thread_index/thread_index.cc
@@ -181,13 +181,6 @@ namespace Astroid {
     // }}}
   }
 
-  void ThreadIndex::refresh_stats (Db * db) {
-    /* stats */
-    log << debug << "ti: refresh stats." << endl;
-
-    queryloader.refresh_stats (db);
-  }
-
   void ThreadIndex::on_stats_ready () {
     log << debug << "ti: got refresh stats." << endl;
     set_label (get_label ());

--- a/src/modes/thread_index/thread_index.cc
+++ b/src/modes/thread_index/thread_index.cc
@@ -189,6 +189,7 @@ namespace Astroid {
   }
 
   void ThreadIndex::on_stats_ready () {
+    log << debug << "ti: got refresh stats." << endl;
     set_label (get_label ());
     list_view->update_bg_image ();
   }

--- a/src/modes/thread_index/thread_index.cc
+++ b/src/modes/thread_index/thread_index.cc
@@ -194,9 +194,9 @@ namespace Astroid {
 
   ustring ThreadIndex::get_label () {
     if (name == "")
-      return ustring::compose ("%1 (%2/%3)", query_string, queryloader.unread_messages, queryloader.total_messages);
+      return ustring::compose ("%1 (%2/%3)%4", query_string, queryloader.unread_messages, queryloader.total_messages, queryloader.loading() ? " (%)" : "");
     else
-      return ustring::compose ("%1 (%2/%3)", name, queryloader.unread_messages, queryloader.total_messages);
+      return ustring::compose ("%1 (%2/%3)%4", name, queryloader.unread_messages, queryloader.total_messages, queryloader.loading() ? " (%)" : "");
   }
 
   void ThreadIndex::open_thread (refptr<NotmuchThread> thread, bool new_tab, bool new_window) {

--- a/src/modes/thread_index/thread_index.cc
+++ b/src/modes/thread_index/thread_index.cc
@@ -217,6 +217,7 @@ namespace Astroid {
     notmuch_query_destroy (unread_q);
 
     set_label (get_label ());
+    list_view->update_bg_image ();
   }
 
   ustring ThreadIndex::get_label () {
@@ -281,7 +282,6 @@ namespace Astroid {
     log << debug << "ti: load more (all: " << all << ", count: " << count << ") threads.." << endl;
 
     Db db (Db::DATABASE_READ_ONLY);
-    refresh_stats (&db);
 
     /* set up query */
     notmuch_query_t * query;
@@ -360,11 +360,11 @@ namespace Astroid {
       }
     }
 
-    list_view->update_bg_image ();
-
     /* closing query */
     notmuch_threads_destroy (threads);
     notmuch_query_destroy (query);
+
+    refresh_stats (&db);
 
     log << info << "ti: loaded " << i << " threads in " << ((clock()-t0) * 1000.0 / CLOCKS_PER_SEC) << " ms." << endl;
   }

--- a/src/modes/thread_index/thread_index.hh
+++ b/src/modes/thread_index/thread_index.hh
@@ -17,8 +17,6 @@ namespace Astroid {
       ThreadIndex (MainWindow *, ustring, ustring = "");
       ~ThreadIndex ();
 
-      void refresh_stats (Db *);
-
       QueryLoader queryloader;
 
       void open_thread (refptr<NotmuchThread>, bool new_tab, bool new_window = false);

--- a/src/modes/thread_index/thread_index.hh
+++ b/src/modes/thread_index/thread_index.hh
@@ -7,9 +7,8 @@
 # include <gtkmm/liststore.h>
 # include <gtkmm/scrolledwindow.h>
 
-# include <notmuch.h>
-
 # include "modes/paned_mode.hh"
+# include "query_loader.hh"
 
 namespace Astroid {
 
@@ -18,16 +17,9 @@ namespace Astroid {
       ThreadIndex (MainWindow *, ustring, ustring = "");
       ~ThreadIndex ();
 
-      unsigned int total_messages;
-      unsigned int unread_messages;
-
-      int thread_load_step;             /* configurable */
-      int current_threads_loaded  = 0;
-
-      void load_more_threads (bool all = false, int count = -1);
-      void refresh (bool all, int count);
       void refresh_stats (Db *);
-      int reopen_tries = 0;
+
+      QueryLoader queryloader;
 
       void open_thread (refptr<NotmuchThread>, bool new_tab, bool new_window = false);
       ThreadView * thread_view;
@@ -44,7 +36,7 @@ namespace Astroid {
       virtual ustring get_label () override;
 
     private:
-      notmuch_sort_t sort;
-      std::vector<ustring> sort_strings = { "oldest", "newest", "messageid", "unsorted" };
+      void on_stats_ready ();
+      void on_first_thread_ready ();
   };
 }

--- a/src/modes/thread_index/thread_index.hh
+++ b/src/modes/thread_index/thread_index.hh
@@ -21,13 +21,11 @@ namespace Astroid {
       unsigned int total_messages;
       unsigned int unread_messages;
 
-      int thread_load_step    = 150;
-      int current_thread      = 0;
+      int thread_load_step;             /* configurable */
+      int current_threads_loaded  = 0;
 
-      void load_more_threads (bool all = false, int count = -1, bool checked = false);
-      void refresh (bool, int, bool);
-      void setup_query ();
-      void close_query ();
+      void load_more_threads (bool all = false, int count = -1);
+      void refresh (bool all, int count);
       void refresh_stats (Db *);
       int reopen_tries = 0;
 
@@ -42,10 +40,6 @@ namespace Astroid {
 
       ustring name = ""; // used as title for default queries
       ustring query_string;
-
-      Db * db = NULL;
-      notmuch_query_t   * query;
-      notmuch_threads_t * threads;
 
       virtual ustring get_label () override;
 

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -26,6 +26,7 @@
 # include "actions/tag_action.hh"
 # include "actions/toggle_action.hh"
 # include "actions/difftag_action.hh"
+# include "actions/cmdaction.hh"
 
 using namespace std;
 
@@ -863,12 +864,10 @@ namespace Astroid {
 
           if (t) {
             cmd = ustring::compose (cmd, t->thread_id);
-            int r = Cmd ("thread_index.run", cmd).run ();
 
-            if (r == 0) {
-              Db db;
-              astroid->actions->emit_thread_updated (&db, t->thread_id);
-            }
+            astroid->actions->doit (refptr<Action> (new CmdAction (
+                    Cmd ("thread_index.run", cmd), t->thread_id, "")));
+
           }
 
           return true;

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -719,8 +719,7 @@ namespace Astroid {
         [&] (Key) {
           auto thread = get_current_thread ();
           if (thread) {
-            Db db (Db::DbMode::DATABASE_READ_WRITE);
-            main_window->actions.doit (&db, refptr<Action>(new ToggleAction(thread, "inbox")));
+            main_window->actions->doit (refptr<Action>(new ToggleAction(thread, "inbox")));
           }
 
           return true;
@@ -731,9 +730,7 @@ namespace Astroid {
         [&] (Key) {
           auto thread = get_current_thread ();
           if (thread) {
-
-            Db db (Db::DbMode::DATABASE_READ_WRITE);
-            main_window->actions.doit (&db, refptr<Action>(new ToggleAction(thread, "flagged")));
+            main_window->actions->doit (refptr<Action>(new ToggleAction(thread, "flagged")));
           }
 
           return true;
@@ -744,9 +741,7 @@ namespace Astroid {
         [&] (Key) {
           auto thread = get_current_thread ();
           if (thread) {
-
-            Db db (Db::DbMode::DATABASE_READ_WRITE);
-            main_window->actions.doit (&db, refptr<Action>(new ToggleAction(thread, "unread")));
+            main_window->actions->doit (refptr<Action>(new ToggleAction(thread, "unread")));
           }
 
           return true;
@@ -757,9 +752,7 @@ namespace Astroid {
         [&] (Key) {
           auto thread = get_current_thread ();
           if (thread) {
-
-            Db db (Db::DbMode::DATABASE_READ_WRITE);
-            main_window->actions.doit (&db, refptr<Action>(new SpamAction(thread)));
+            main_window->actions->doit (refptr<Action>(new SpamAction(thread)));
           }
 
           return true;
@@ -770,9 +763,7 @@ namespace Astroid {
         [&] (Key) {
           auto thread = get_current_thread ();
           if (thread) {
-
-            Db db (Db::DbMode::DATABASE_READ_WRITE);
-            main_window->actions.doit (&db, refptr<Action>(new MuteAction(thread)));
+            main_window->actions->doit (refptr<Action>(new MuteAction(thread)));
           }
 
           return true;
@@ -820,9 +811,7 @@ namespace Astroid {
                       rem.size () == 0) {
                     log << debug << "ti: nothing to do." << endl;
                   } else {
-                    Db db (Db::DbMode::DATABASE_READ_WRITE);
-                    main_window->actions.doit (&db,
-                       refptr<Action>(new TagAction (thread, add, rem)));
+                    main_window->actions->doit (refptr<Action>(new TagAction (thread, add, rem)));
                   }
                 });
           }
@@ -878,7 +867,7 @@ namespace Astroid {
 
             if (r == 0) {
               Db db;
-              astroid->global_actions->emit_thread_updated (&db, t->thread_id);
+              astroid->actions->emit_thread_updated (&db, t->thread_id);
             }
           }
 
@@ -955,8 +944,7 @@ namespace Astroid {
 
                       refptr<Action> ma = refptr<DiffTagAction> (DiffTagAction::create (threads, tgs));
                       if (ma) {
-                        Db db (Db::DbMode::DATABASE_READ_WRITE);
-                        main_window->actions.doit (&db, ma);
+                        main_window->actions->doit (ma);
                       }
                     });
                 return true;
@@ -968,8 +956,7 @@ namespace Astroid {
           }
 
           if ((maction != MTag) && a) {
-            Db db (Db::DbMode::DATABASE_READ_WRITE);
-            main_window->actions.doit (&db, a);
+            main_window->actions->doit (a);
           }
 
           return true;
@@ -1053,10 +1040,7 @@ namespace Astroid {
       case Flag:
         {
           if (thread) {
-
-            Db db (Db::DbMode::DATABASE_READ_WRITE);
-            main_window->actions.doit (&db, refptr<Action>(new ToggleAction(thread, "flagged")));
-
+            main_window->actions->doit (refptr<Action>(new ToggleAction(thread, "flagged")));
           }
         }
         break;
@@ -1064,10 +1048,7 @@ namespace Astroid {
       case Archive:
         {
           if (thread) {
-
-            Db db (Db::DbMode::DATABASE_READ_WRITE);
-            main_window->actions.doit (&db, refptr<Action>(new ToggleAction(thread, "inbox")));
-
+            main_window->actions->doit (refptr<Action>(new ToggleAction(thread, "inbox")));
           }
         }
         break;

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -1147,8 +1147,8 @@ namespace Astroid {
   }
 
   void ThreadIndexListView::on_refreshed () {
-    log << debug << "til: got refreshed signal." << endl;
-    thread_index->refresh (false, max(thread_index->thread_load_step, thread_index->current_thread), false);
+    log << warn << "til: got refreshed signal." << endl;
+    thread_index->refresh (false, max(thread_index->thread_load_step, thread_index->current_threads_loaded));
   }
 
   void ThreadIndexListView::on_thread_changed (Db * db, ustring thread_id) {
@@ -1211,6 +1211,9 @@ namespace Astroid {
         log << debug << "til: deleted" << endl;
         path = list_store->get_path (fwditer);
         list_store->erase (fwditer);
+
+        /* decrement loaded threads count */
+        thread_index->current_threads_loaded--;
       }
 
     } else {

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -1242,6 +1242,9 @@ namespace Astroid {
           auto p = Gtk::TreePath("0");
           if (p) set_cursor (p);
         }
+
+        /* increment loaded threads count */
+        thread_index->current_threads_loaded++;
       }
     }
 

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -1219,7 +1219,7 @@ namespace Astroid {
   }
 
   void ThreadIndexListView::update_bg_image () {
-    bool hide = (list_store->children().empty());
+    bool hide = (thread_index->queryloader.total_messages == 0);
 
     if (!hide) {
       auto sc = get_style_context ();

--- a/src/modes/thread_index/thread_index_list_view.hh
+++ b/src/modes/thread_index/thread_index_list_view.hh
@@ -105,9 +105,6 @@ namespace Astroid {
       // bypass scrolled window
       virtual bool on_key_press_event (GdkEventKey *) override;
 
-      void on_thread_changed (Db *, ustring);
-      void on_refreshed ();
-
     private:
       std::chrono::time_point<std::chrono::steady_clock> last_redraw;
       bool redraw ();

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -179,7 +179,7 @@ namespace Astroid {
 
     show_all_children ();
 
-    astroid->global_actions->signal_thread_updated ().connect (
+    astroid->actions->signal_thread_updated ().connect (
         sigc::mem_fun (this, &ThreadView::on_thread_updated));
   }
 
@@ -742,8 +742,7 @@ namespace Astroid {
      *
      */
     if (mthread->in_notmuch && mthread->thread->has_tag ("unread")) {
-      Db db (Db::DbMode::DATABASE_READ_WRITE);
-      main_window->actions.doit (&db, refptr<Action>(new TagAction(mthread->thread, {}, {"unread"})));
+      main_window->actions->doit (refptr<Action>(new TagAction(mthread->thread, {}, {"unread"})));
     }
 
     emit_ready ();
@@ -2444,9 +2443,7 @@ namespace Astroid {
                     rem.size () == 0) {
                   log << debug << "ti: nothing to do." << endl;
                 } else {
-                  Db db (Db::DbMode::DATABASE_READ_WRITE);
-                  main_window->actions.doit (&db,
-                     refptr<Action>(new TagAction (refptr<NotmuchTaggable>(new NotmuchMessage(focused_message)), add, rem)));
+                  main_window->actions->doit (refptr<Action>(new TagAction (refptr<NotmuchTaggable>(new NotmuchMessage(focused_message)), add, rem)));
                 }
 
               });

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -578,7 +578,6 @@ namespace Astroid {
     set_label (thread->thread_id);
 
     Db db (Db::DbMode::DATABASE_READ_ONLY);
-    lock_guard<Db> grd (db);
 
     auto _mthread = refptr<MessageThread>(new MessageThread (thread));
     _mthread->load_messages (&db);

--- a/src/poll.cc
+++ b/src/poll.cc
@@ -238,7 +238,7 @@ namespace Astroid {
             const char * t = notmuch_thread_get_thread_id (thread);
 
             ustring tt (t);
-            astroid->global_actions->emit_thread_updated (&db, tt);
+            astroid->actions->emit_thread_updated (&db, tt);
           }
         }
 
@@ -248,7 +248,7 @@ namespace Astroid {
 
       last_good_before_poll_revision = revnow;
 # else
-      astroid->global_actions->signal_refreshed_dispatcher ();
+      astroid->actions->signal_refreshed_dispatcher ();
 # endif
     }
 

--- a/src/proto.hh
+++ b/src/proto.hh
@@ -32,7 +32,6 @@ namespace Astroid {
   class ComposeMessage;
 
   /* actions */
-  class GlobalActions;
   class ActionManager;
   class Action;
   class TagAction;

--- a/src/utils/cmd.cc
+++ b/src/utils/cmd.cc
@@ -20,6 +20,10 @@ namespace Astroid {
     cmd = substitute (_cmd);
   }
 
+  Cmd::Cmd () {
+
+  }
+
   int Cmd::run () {
     log << info << "cmd: running: " << cmd << endl;
     string _stdout;

--- a/src/utils/cmd.hh
+++ b/src/utils/cmd.hh
@@ -10,6 +10,7 @@
 namespace Astroid {
   class Cmd {
     public:
+      Cmd ();
       Cmd (ustring prefix, ustring cmd);
       Cmd (ustring cmd);
 


### PR DESCRIPTION
keeping notmuch query objects alive for a long while causes issues since
they are quite fragile to outside (or inside database changes). all
internal changes to the database (including polling with notmuch lastmod
functionality) should be caught.

this patch loads all threads in the background while the user interface remains responsive, there are some threading complications that needs particular attention:
- changing threads while loading: in case the thread has not been loaded yet (**deferred**)
- adding / deleting threads which have not been added yet (**deferred**)
- invalidated query while loading: what do we do? restart? defer the action to loading is done (blocking the UI)? (**currently deferring**)