### PR TITLE
saved searches: show startup queries

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -6,7 +6,8 @@
 * Signatures: Include per-account signatures (either included or
   attached).
 * Saved searches: Save a search with 'C-S', then browse saved searches
-  and stats with 'C-f'.
+  and stats with 'C-f'. You can also browse search history using Up
+  and Down in the search-bar.
 * All actions requiring write-access run in the background and wait for
   any reads to finish. All read operations need to wait for any ongoing
   write-operations to finish. All write-operations are therefore

--- a/History.txt
+++ b/History.txt
@@ -5,6 +5,8 @@
 * General XEmbed support in editor: Emacs works.
 * Signatures: Include per-account signatures (either included or
   attached).
+* Saved searches: Save a search with 'C-S', then browse saved searches
+  and stats with 'C-f'.
 * All actions requiring write-access run in the background and wait for
   any reads to finish. All read operations need to wait for any ongoing
   write-operations to finish. All write-operations are therefore

--- a/src/astroid.hh
+++ b/src/astroid.hh
@@ -51,6 +51,8 @@ namespace Astroid {
       void on_mailto_activate (const Glib::VariantBase &);
       refptr<Gio::SimpleAction> mailto;
       void send_mailto (MainWindow * mw, ustring);
+
+      void on_quit ();
   };
 
   /* globally available instance of our main Astroid-class */

--- a/src/command_bar.cc
+++ b/src/command_bar.cc
@@ -548,6 +548,7 @@ namespace Astroid {
 
   void CommandBar::SearchCompletion::load_history () {
     history = SavedSearches::get_history ();
+    std::reverse (history.begin (), history.end ());
   }
 
   void CommandBar::SearchCompletion::load_tags (vector<ustring> _tags) {

--- a/src/command_bar.cc
+++ b/src/command_bar.cc
@@ -170,6 +170,7 @@ namespace Astroid {
 
     /* set up completion */
     search_completion->load_tags (Db::tags);
+    search_completion->load_history ();
     entry.set_completion (search_completion);
     current_completion = search_completion;
   }
@@ -239,6 +240,68 @@ namespace Astroid {
           }
 
           return true;
+        }
+
+      case GDK_KEY_Up:
+        {
+          if (mode == CommandMode::Search) {
+            log << debug << "cb: next history" << endl;
+
+            refptr<SearchCompletion> s = refptr<SearchCompletion>::cast_dynamic (current_completion);
+
+            if (s->history.empty ()) return true;
+
+            /* save original */
+            if (s->orig_text == "") {
+              s->orig_text = entry.get_text ();
+            }
+
+            if (s->history.size() >= (s->history_pos+1)) {
+
+              s->history_pos++;
+              entry.set_text (s->history[s->history_pos -1]);
+            }
+
+            return true;
+          } else {
+            return false;
+          }
+        }
+
+      case GDK_KEY_Down:
+        {
+          if (mode == CommandMode::Search) {
+            log << debug << "cb: previous history" << endl;
+
+           refptr<SearchCompletion> s = refptr<SearchCompletion>::cast_dynamic (current_completion);
+
+            if (s->history.empty ()) return true;
+
+            if (s->history_pos > 0) {
+              s->history_pos--;
+              if (s->history_pos == 0) {
+                entry.set_text (s->orig_text);
+                s->orig_text = "";
+              } else {
+                entry.set_text (s->history[s->history_pos -1]);
+              }
+            }
+
+            return true;
+          } else {
+            return false;
+          }
+        }
+
+      default:
+        {
+          if (mode == CommandMode::Search) {
+            /* reset history browsing */
+            refptr<SearchCompletion> s = refptr<SearchCompletion>::cast_dynamic (current_completion);
+            s->orig_text = "";
+            s->history_pos = 0;
+          }
+          break;
         }
     }
 
@@ -481,6 +544,10 @@ namespace Astroid {
     set_popup_completion (true);
     set_popup_single_match (true);
     set_minimum_key_length (1);
+  }
+
+  void CommandBar::SearchCompletion::load_history () {
+    history = SavedSearches::get_history ();
   }
 
   void CommandBar::SearchCompletion::load_tags (vector<ustring> _tags) {

--- a/src/command_bar.cc
+++ b/src/command_bar.cc
@@ -12,6 +12,7 @@
 # include "modes/mode.hh"
 # include "modes/thread_index/thread_index.hh"
 # include "modes/help_mode.hh"
+# include "modes/saved_searches.hh"
 # include "utils/utils.hh"
 # include "log.hh"
 # include "db.hh"
@@ -69,6 +70,9 @@ namespace Astroid {
       case CommandMode::Search:
         if (callback == NULL && (cmd.size() > 0)) {
           Mode * m = new ThreadIndex (main_window, cmd);
+
+          /* add to saved searches */
+          SavedSearches::add_query_to_history (cmd);
 
           main_window->add_mode (m);
         }

--- a/src/command_bar.hh
+++ b/src/command_bar.hh
@@ -160,6 +160,13 @@ namespace Astroid {
         public:
           SearchCompletion ();
 
+          /* original text when browsing through search history */
+          void load_history ();
+          ustring orig_text = "";
+          unsigned int history_pos;
+          std::vector <ustring> history;
+
+
           void load_tags (std::vector<ustring>);
           std::vector<ustring> tags; // must be sorted
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -77,6 +77,9 @@ namespace Astroid {
       }
     }
 
+    /* searches file */
+    std_paths.searches_file = std_paths.config_dir / path("searches");
+
     /* default data */
     char * data = getenv ("XDG_DATA_HOME");
     if (data == NULL) {
@@ -100,6 +103,7 @@ namespace Astroid {
     } else {
       std_paths.runtime_dir = path(runtime) / path("astroid");
     }
+
   }
 
   ptree Config::setup_default_config (bool initial) {
@@ -283,6 +287,7 @@ namespace Astroid {
       config.get<std::string> ("astroid.notmuch_config"),
       notmuch_config);
   }
+
 
   bool Config::check_config (ptree new_config) {
     bool changed = false;

--- a/src/config.cc
+++ b/src/config.cc
@@ -233,6 +233,9 @@ namespace Astroid {
     /* crypto */
     default_config.put ("crypto.gpg.path", "gpg2");
 
+    /* saved searches */
+    default_config.put ("saved_searches.save_history", true);
+
     return default_config;
   }
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -237,6 +237,7 @@ namespace Astroid {
     default_config.put ("saved_searches.show_on_startup", true);
     default_config.put ("saved_searches.save_history", true);
     default_config.put ("saved_searches.history_lines_to_show", -1); /* -1 is all */
+    default_config.put ("saved_searches.history_lines", 1000); /* number of history lines to store */
 
     return default_config;
   }

--- a/src/config.cc
+++ b/src/config.cc
@@ -234,9 +234,9 @@ namespace Astroid {
     default_config.put ("crypto.gpg.path", "gpg2");
 
     /* saved searches */
-    default_config.put ("saved_searches.show_on_startup", true);
+    default_config.put ("saved_searches.show_on_startup", false);
     default_config.put ("saved_searches.save_history", true);
-    default_config.put ("saved_searches.history_lines_to_show", -1); /* -1 is all */
+    default_config.put ("saved_searches.history_lines_to_show", 15); /* -1 is all */
     default_config.put ("saved_searches.history_lines", 1000); /* number of history lines to store */
 
     return default_config;

--- a/src/config.cc
+++ b/src/config.cc
@@ -234,6 +234,7 @@ namespace Astroid {
     default_config.put ("crypto.gpg.path", "gpg2");
 
     /* saved searches */
+    default_config.put ("saved_searches.show_on_startup", true);
     default_config.put ("saved_searches.save_history", true);
     default_config.put ("saved_searches.history_lines_to_show", -1); /* -1 is all */
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -235,6 +235,7 @@ namespace Astroid {
 
     /* saved searches */
     default_config.put ("saved_searches.save_history", true);
+    default_config.put ("saved_searches.history_lines_to_show", -1); /* -1 is all */
 
     return default_config;
   }

--- a/src/config.hh
+++ b/src/config.hh
@@ -19,6 +19,7 @@ namespace Astroid {
     bfs::path cache_dir;
     bfs::path runtime_dir;
     bfs::path config_file;
+    bfs::path searches_file;
   };
 
   class Config {

--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -9,6 +9,7 @@
 # include "main_window.hh"
 # include "modes/mode.hh"
 # include "modes/thread_index/thread_index.hh"
+# include "modes/saved_searches.hh"
 # include "modes/help_mode.hh"
 # include "modes/edit_message.hh"
 # include "modes/log_view.hh"
@@ -219,6 +220,13 @@ namespace Astroid {
         "Search",
         [&] (Key) {
           enable_command (CommandBar::CommandMode::Search, "", NULL);
+          return true;
+        });
+
+    keys.register_key ("C-f", "main_window.show_saved_searches",
+        "Show saved searches",
+        [&] (Key) {
+          add_mode (new SavedSearches (this));
           return true;
         });
 

--- a/src/modes/saved_searches.cc
+++ b/src/modes/saved_searches.cc
@@ -313,13 +313,14 @@ namespace Astroid {
 
           iter = store->get_iter (path);
           Gtk::ListStore::Row row = *iter;
-          /* return row[list_store->columns.thread]; */
 
-          ustring query = row[m_columns.m_col_query];
-          ustring name  = row[m_columns.m_col_name];
+          if (!row[m_columns.m_col_description]) {
+            ustring query = row[m_columns.m_col_query];
+            ustring name  = row[m_columns.m_col_name];
 
-          Mode * ti = new ThreadIndex (main_window, query, name);
-          main_window->add_mode (ti);
+            Mode * ti = new ThreadIndex (main_window, query, name);
+            main_window->add_mode (ti);
+          }
 
           return true;
         });
@@ -328,6 +329,9 @@ namespace Astroid {
 
     reload ();
     tv.set_cursor (Gtk::TreePath("1"));
+
+    tv.signal_row_activated ().connect (
+        sigc::mem_fun (this, &SavedSearches::on_my_row_activated));
 
     SavedSearches::m_reload.connect (
         sigc::mem_fun (this, &SavedSearches::reload));
@@ -338,6 +342,28 @@ namespace Astroid {
     astroid->actions->signal_refreshed ().connect (
         sigc::mem_fun (this, &SavedSearches::reload));
   }
+
+  void SavedSearches::on_my_row_activated (
+      const Gtk::TreeModel::Path &,
+      Gtk::TreeViewColumn *) {
+
+    Gtk::TreePath path;
+    Gtk::TreeViewColumn *c;
+    tv.get_cursor (path, c);
+    Gtk::TreeIter iter;
+
+    iter = store->get_iter (path);
+    Gtk::ListStore::Row row = *iter;
+
+    if (!row[m_columns.m_col_description]) {
+      ustring query = row[m_columns.m_col_query];
+      ustring name  = row[m_columns.m_col_name];
+
+      Mode * ti = new ThreadIndex (main_window, query, name);
+      main_window->add_mode (ti);
+    }
+  }
+
 
   void SavedSearches::reload () {
     Gtk::TreePath path;

--- a/src/modes/saved_searches.cc
+++ b/src/modes/saved_searches.cc
@@ -99,6 +99,31 @@ namespace Astroid {
           return true;
         });
 
+    keys.register_key ("s",
+        "searches.save",
+        "Save recent query as saved search",
+        [&] (Key) {
+          Gtk::TreePath path;
+          Gtk::TreeViewColumn *c;
+          tv.get_cursor (path, c);
+
+          Gtk::TreeIter it = store->get_iter (path);
+          auto row = *it;
+
+          if (row[m_columns.m_col_history]) {
+            ustring query = row[m_columns.m_col_query];
+
+            log << "searches: saving query: " << query << endl;
+            save_query (query);
+
+          } else {
+            log << debug << "searches: entry not a recent search." << endl;
+            return true;
+          }
+
+          return true;
+        });
+
     keys.register_key ("d",
         "searches.delete",
         "Delete saved query",
@@ -116,7 +141,8 @@ namespace Astroid {
             ustring query = row[m_columns.m_col_query];
 
             if (row[m_columns.m_col_saved]) {
-              ptree s = load_searches ().get_child ("saved");
+              ptree sa = load_searches ();
+              ptree  s = sa.get_child ("saved");
 
               /* TODO: warning, this will delete the first occurence of the query */
               for (auto it = s.begin (); it != s.end ();) {
@@ -131,10 +157,13 @@ namespace Astroid {
                 }
               }
 
-              if (changed) write_back_searches (s);
+              sa.put_child ("saved", s);
+
+              if (changed) write_back_searches (sa);
 
             } else if (row[m_columns.m_col_history]) {
-              ptree s = load_searches ().get_child ("history");
+              ptree sa = load_searches ();
+              ptree  s = sa.get_child ("history");
 
               /* TODO: warning, this will delete the first occurence of the query */
               for (auto it = s.begin (); it != s.end ();) {
@@ -149,7 +178,9 @@ namespace Astroid {
                 }
               }
 
-              if (changed) write_back_searches (s);
+              sa.put_child ("history", s);
+
+              if (changed) write_back_searches (sa);
             }
 
             if (changed) {

--- a/src/modes/saved_searches.cc
+++ b/src/modes/saved_searches.cc
@@ -259,6 +259,8 @@ namespace Astroid {
 
   void SavedSearches::refresh_stats () {
     for (auto row : store->children ()) {
+      if (row[m_columns.m_col_description]) continue;
+
       ustring query = row[m_columns.m_col_query];
 
       unsigned int total_messages, unread_messages;

--- a/src/modes/saved_searches.cc
+++ b/src/modes/saved_searches.cc
@@ -385,6 +385,9 @@ namespace Astroid {
 
     row[m_columns.m_col_name] = "<b>Search history</b>";
     row[m_columns.m_col_description] = true;
+
+    std::vector<std::pair<ustring, ustring>> history;
+
     for (auto &kv : searches.get_child ("history")) {
       ustring name = kv.first;
       ustring query = kv.second.data();
@@ -392,8 +395,13 @@ namespace Astroid {
       if (name == "none") name = "";
 
       log << debug << "saved searches, history: got query: " << name << ": " << query << endl;
-      add_query (name, query, false, true);
+      history.push_back (std::make_pair (name, query));
     }
+
+    for (auto it = history.rbegin (); it != history.rend (); ++it) {
+      add_query (it->first, it->second, false, true);
+    }
+
   }
 
   ptree SavedSearches::load_searches () {

--- a/src/modes/saved_searches.cc
+++ b/src/modes/saved_searches.cc
@@ -13,6 +13,7 @@ using boost::property_tree::ptree;
 using std::endl;
 
 namespace Astroid {
+  Glib::Dispatcher SavedSearches::m_reload;
 
   SavedSearches::SavedSearches (MainWindow * mw) : Mode (mw) {
     set_label ("Saved searches");
@@ -160,10 +161,23 @@ namespace Astroid {
 
     /* }}} */
 
+    reload ();
+    tv.set_cursor (Gtk::TreePath("1"));
+
+    SavedSearches::m_reload.connect (
+        sigc::mem_fun (this, &SavedSearches::reload));
+  }
+
+  void SavedSearches::reload () {
+    Gtk::TreePath path;
+    Gtk::TreeViewColumn *c;
+    tv.get_cursor (path, c);
+
+    store->clear ();
     load_startup_queries ();
     load_saved_searches ();
 
-    tv.set_cursor (Gtk::TreePath("1"));
+    tv.set_cursor (path);
   }
 
   void SavedSearches::add_query (ustring name, ustring query) {
@@ -294,6 +308,8 @@ namespace Astroid {
     ptree s = load_searches ();
     s.add ("none", q);
     write_back_searches (s);
+
+    m_reload ();
   }
 
   void SavedSearches::grab_modal () {

--- a/src/modes/saved_searches.cc
+++ b/src/modes/saved_searches.cc
@@ -105,6 +105,7 @@ namespace Astroid {
           Gtk::TreeViewColumn *c;
           tv.get_cursor (path, c);
 
+          bool changed = false;
           Gtk::TreeIter it = store->get_iter (path);
           if (it) {
 
@@ -114,7 +115,6 @@ namespace Astroid {
 
             if (row[m_columns.m_col_saved]) {
               ptree s = load_searches ().get_child ("saved");
-              bool changed = false;
 
               /* TODO: warning, this will delete the first occurence of the query */
               for (auto it = s.begin (); it != s.end ();) {
@@ -133,7 +133,6 @@ namespace Astroid {
 
             } else if (row[m_columns.m_col_history]) {
               ptree s = load_searches ().get_child ("history");
-              bool changed = false;
 
               /* TODO: warning, this will delete the first occurence of the query */
               for (auto it = s.begin (); it != s.end ();) {
@@ -149,6 +148,17 @@ namespace Astroid {
               }
 
               if (changed) write_back_searches (s);
+            }
+
+            if (changed) {
+              /* select new row */
+              path.prev ();
+              Gtk::TreeIter it = store->get_iter (path);
+              if (it) {
+                tv.set_cursor (path);
+              } else {
+                tv.set_cursor (Gtk::TreePath ("1"));
+              }
             }
 
 

--- a/src/modes/saved_searches.cc
+++ b/src/modes/saved_searches.cc
@@ -480,6 +480,10 @@ namespace Astroid {
       add_query (name, query, true);
     }
 
+    int history_lines = astroid->config ("saved_searches").get<int> ("history_lines_to_show");
+
+    if (history_lines == 0) return;
+
     /* load search history */
     iter = store->append();
     row  = *iter;
@@ -499,8 +503,14 @@ namespace Astroid {
       history.push_back (std::make_pair (name, query));
     }
 
+    int i = 0;
+
     for (auto it = history.rbegin (); it != history.rend (); ++it) {
+      if (!((history_lines < 0) || (i < history_lines))) break;
+
       add_query (it->first, it->second, false, true);
+
+      i++;
     }
 
   }

--- a/src/modes/saved_searches.cc
+++ b/src/modes/saved_searches.cc
@@ -404,6 +404,27 @@ namespace Astroid {
 
   }
 
+  std::vector<ustring> SavedSearches::get_history () {
+    ptree searches = load_searches ();
+
+    /* load search history */
+    std::vector<ustring> history;
+
+    for (auto &kv : searches.get_child ("history")) {
+      ustring name = kv.first;
+      ustring query = kv.second.data();
+
+      if (name == "none") name = "";
+
+      log << debug << "saved searches, history: got query: " << name << ": " << query << endl;
+      history.push_back (query);
+    }
+
+    std::reverse (history.begin (), history.end ());
+
+    return history;
+  }
+
   ptree SavedSearches::load_searches () {
     ptree s;
 

--- a/src/modes/saved_searches.cc
+++ b/src/modes/saved_searches.cc
@@ -550,11 +550,16 @@ namespace Astroid {
   void SavedSearches::destruct () {
     /* writing search history */
     bool save = astroid->config ("saved_searches").get<bool> ("save_history");
+    unsigned int maxh = astroid->config ("saved_searches").get<unsigned int>  ("history_lines");
 
     if (save) {
       log << debug << "searches: saving history.." << endl;
       ptree s = load_searches ();
       ptree h;
+
+      if (history.size () > maxh) {
+        history.erase (history.end () - maxh, history.end ());
+      }
 
       for (auto &k : history) {
         h.add ("none", k);

--- a/src/modes/saved_searches.cc
+++ b/src/modes/saved_searches.cc
@@ -1,0 +1,197 @@
+# include "saved_searches.hh"
+# include "astroid.hh"
+# include "config.hh"
+# include "log.hh"
+# include "main_window.hh"
+# include "thread_index/thread_index.hh"
+# include "db.hh"
+
+using std::endl;
+
+namespace Astroid {
+
+  SavedSearches::SavedSearches (MainWindow * mw) : Mode (mw) {
+    set_label ("Saved searches");
+
+    scroll.add (tv);
+    pack_start (scroll);
+
+    store = Gtk::ListStore::create (m_columns);
+    tv.set_model (store);
+
+    tv.append_column ("Name", m_columns.m_col_name);
+    tv.append_column ("Query", m_columns.m_col_query);
+    tv.append_column ("Unread messages", m_columns.m_col_unread_messages);
+    tv.append_column ("Total messages ", m_columns.m_col_total_messages);
+
+    tv.set_headers_visible (false);
+    tv.set_sensitive (true);
+    set_sensitive (true);
+    set_can_focus (true);
+
+    show_all_children ();
+
+    /* register keys {{{ */
+    keys.title = "Saved searches";
+    keys.register_key ("j", { Key (GDK_KEY_Down) },
+        "searches.down",
+        "Move cursor down",
+        [&] (Key) {
+          if (store->children().size() < 2)
+            return true;
+
+          Gtk::TreePath path;
+          Gtk::TreeViewColumn *c;
+          tv.get_cursor (path, c);
+
+          path.next ();
+          Gtk::TreeIter it = store->get_iter (path);
+
+          if (it) {
+            tv.set_cursor (path);
+          }
+
+          return true;
+        });
+
+    keys.register_key ("k", { Key (GDK_KEY_Up) },
+        "searches.up",
+        "Move cursor up",
+        [&] (Key) {
+          Gtk::TreePath path;
+          Gtk::TreeViewColumn *c;
+          tv.get_cursor (path, c);
+          path.prev ();
+          if (path) {
+            tv.set_cursor (path);
+          }
+          return true;
+        });
+
+    keys.register_key ("J",
+        "searches.page_down",
+        "Page down",
+        [&] (Key) {
+          auto adj = tv.get_vadjustment ();
+          adj->set_value (adj->get_value() + adj->get_step_increment ());
+          return true;
+        });
+
+    keys.register_key ("K",
+        "searches.page_up",
+        "Page up",
+        [&] (Key) {
+          auto adj = tv.get_vadjustment ();
+          adj->set_value (adj->get_value() - adj->get_step_increment ());
+          return true;
+        });
+
+    keys.register_key ("1", { Key (GDK_KEY_Home) },
+        "searches.home",
+        "Scroll home",
+        [&] (Key) {
+          /* select first */
+          tv.set_cursor (Gtk::TreePath("0"));
+          return true;
+        });
+
+    keys.register_key ("0", { Key (GDK_KEY_End) },
+        "searches.end",
+        "Scroll to end",
+        [&] (Key) {
+          /* select last */
+          auto it = store->children().end ();
+          auto p  = store->get_path (--it);
+          tv.set_cursor (p);
+
+          return true;
+        });
+
+    keys.register_key (Key (GDK_KEY_Return), { Key (GDK_KEY_KP_Enter) },
+        "searches.open",
+        "Open query",
+        [&] (Key) {
+
+          Gtk::TreePath path;
+          Gtk::TreeViewColumn *c;
+          tv.get_cursor (path, c);
+          Gtk::TreeIter iter;
+
+          iter = store->get_iter (path);
+          Gtk::ListStore::Row row = *iter;
+          /* return row[list_store->columns.thread]; */
+
+          ustring query = row[m_columns.m_col_query];
+          ustring name  = row[m_columns.m_col_name];
+
+          Mode * ti = new ThreadIndex (main_window, query, name);
+          main_window->add_mode (ti); 
+
+          return true;
+        });
+
+    /* }}} */
+
+    load_startup_queries ();
+
+    tv.set_cursor (Gtk::TreePath("0"));
+  }
+
+  void SavedSearches::add_query (ustring name, ustring query) {
+    auto iter = store->append();
+    auto row  = *iter;
+
+    row[m_columns.m_col_name] = name;
+    row[m_columns.m_col_query] = query;
+
+    unsigned int total_messages, unread_messages;
+
+    /* get stats */
+    Db db;
+    notmuch_query_t * query_t =  notmuch_query_create (db.nm_db, query.c_str ());
+    for (ustring & t : db.excluded_tags) {
+      notmuch_query_add_tag_exclude (query_t, t.c_str());
+    }
+    notmuch_query_set_omit_excluded (query_t, NOTMUCH_EXCLUDE_TRUE);
+    /* st = */ notmuch_query_count_messages_st (query_t, &total_messages); // destructive
+    notmuch_query_destroy (query_t);
+
+    ustring unread_q_s = "(" + query + ") AND tag:unread";
+    notmuch_query_t * unread_q = notmuch_query_create (db.nm_db, unread_q_s.c_str());
+    for (ustring & t : db.excluded_tags) {
+      notmuch_query_add_tag_exclude (unread_q, t.c_str());
+    }
+    notmuch_query_set_omit_excluded (unread_q, NOTMUCH_EXCLUDE_TRUE);
+    /* st = */ notmuch_query_count_messages_st (unread_q, &unread_messages); // destructive
+    notmuch_query_destroy (unread_q);
+
+    row[m_columns.m_col_total_messages] = total_messages;
+    row[m_columns.m_col_unread_messages] = unread_messages;
+  }
+
+  void SavedSearches::load_startup_queries () {
+    ptree qpt = astroid->config ("startup.queries");
+
+    for (const auto &kv : qpt) {
+      ustring name = kv.first;
+      ustring query = kv.second.data();
+
+      log << info << "saved searches: got query: " << name << ": " << query << endl;
+      add_query (name, query);
+    }
+  }
+
+  void SavedSearches::grab_modal () {
+    add_modal_grab ();
+    grab_focus ();
+  }
+
+  void SavedSearches::release_modal () {
+    remove_modal_grab ();
+  }
+
+
+
+}
+
+

--- a/src/modes/saved_searches.hh
+++ b/src/modes/saved_searches.hh
@@ -15,7 +15,7 @@ namespace Astroid {
 
       void load_startup_queries ();
       void load_saved_searches ();
-      void add_query (ustring, ustring);
+      void add_query (ustring, ustring, bool saved = false);
 
       void reload ();
       void refresh_stats ();
@@ -23,13 +23,12 @@ namespace Astroid {
       static void save_query (ustring query);
 
     private:
-      ptree searches;
-
       static ptree load_searches ();
       static void write_back_searches (ptree);
 
       static Glib::Dispatcher m_reload;
 
+      void on_thread_changed (Db *, ustring);
 
     protected:
       class ModelColumns : public Gtk::TreeModel::ColumnRecord
@@ -39,6 +38,7 @@ namespace Astroid {
           ModelColumns()
           {
             add (m_col_description);
+            add (m_col_saved);
             add (m_col_name);
             add (m_col_query);
             add (m_col_unread_messages);
@@ -46,6 +46,7 @@ namespace Astroid {
           }
 
           Gtk::TreeModelColumn<bool>          m_col_description;
+          Gtk::TreeModelColumn<bool>          m_col_saved;
           Gtk::TreeModelColumn<Glib::ustring> m_col_name;
           Gtk::TreeModelColumn<Glib::ustring> m_col_query;
           Gtk::TreeModelColumn<Glib::ustring> m_col_unread_messages;

--- a/src/modes/saved_searches.hh
+++ b/src/modes/saved_searches.hh
@@ -16,6 +16,8 @@ namespace Astroid {
       static void save_query (ustring query);
       static void add_query_to_history (ustring query);
 
+      static std::vector<ustring> get_history ();
+
     private:
       static ptree load_searches ();
       static void write_back_searches (ptree);

--- a/src/modes/saved_searches.hh
+++ b/src/modes/saved_searches.hh
@@ -40,6 +40,8 @@ namespace Astroid {
 
       int page_jump_rows;
 
+      void on_my_row_activated (const Gtk::TreeModel::Path &, Gtk::TreeViewColumn *);
+
     protected:
       class ModelColumns : public Gtk::TreeModel::ColumnRecord
       {

--- a/src/modes/saved_searches.hh
+++ b/src/modes/saved_searches.hh
@@ -18,9 +18,15 @@ namespace Astroid {
 
       static std::vector<ustring> get_history ();
 
+      /* called by astroid destructor to save search history */
+      static void init ();
+      static void destruct ();
+
     private:
       static ptree load_searches ();
       static void write_back_searches (ptree);
+
+      static std::vector<ustring> history;
 
       static Glib::Dispatcher m_reload;
 

--- a/src/modes/saved_searches.hh
+++ b/src/modes/saved_searches.hh
@@ -14,6 +14,7 @@ namespace Astroid {
       void release_modal () override;
 
       static void save_query (ustring query);
+      static void add_query_to_history (ustring query);
 
     private:
       static ptree load_searches ();
@@ -24,7 +25,7 @@ namespace Astroid {
       void on_thread_changed (Db *, ustring);
       void load_startup_queries ();
       void load_saved_searches ();
-      void add_query (ustring, ustring, bool saved = false);
+      void add_query (ustring, ustring, bool saved = false, bool history = false);
 
       void reload ();
       void refresh_stats ();
@@ -38,6 +39,7 @@ namespace Astroid {
           {
             add (m_col_description);
             add (m_col_saved);
+            add (m_col_history);
             add (m_col_name);
             add (m_col_query);
             add (m_col_unread_messages);
@@ -46,6 +48,7 @@ namespace Astroid {
 
           Gtk::TreeModelColumn<bool>          m_col_description;
           Gtk::TreeModelColumn<bool>          m_col_saved;
+          Gtk::TreeModelColumn<bool>          m_col_history;
           Gtk::TreeModelColumn<Glib::ustring> m_col_name;
           Gtk::TreeModelColumn<Glib::ustring> m_col_query;
           Gtk::TreeModelColumn<Glib::ustring> m_col_unread_messages;

--- a/src/modes/saved_searches.hh
+++ b/src/modes/saved_searches.hh
@@ -1,6 +1,9 @@
 # pragma once
 
 # include "mode.hh"
+# include <boost/property_tree/ptree.hpp>
+
+using boost::property_tree::ptree;
 
 namespace Astroid {
   class SavedSearches : public Mode {
@@ -11,7 +14,19 @@ namespace Astroid {
       void release_modal () override;
 
       void load_startup_queries ();
+      void load_saved_searches ();
       void add_query (ustring, ustring);
+
+      void refresh_stats ();
+
+      static void save_query (ustring query);
+
+    private:
+      ptree searches;
+
+      static ptree load_searches ();
+      static void write_back_searches (ptree);
+
 
     protected:
       class ModelColumns : public Gtk::TreeModel::ColumnRecord
@@ -19,17 +34,19 @@ namespace Astroid {
         public:
 
           ModelColumns()
-          { 
+          {
+            add (m_col_description);
             add (m_col_name);
             add (m_col_query);
             add (m_col_unread_messages);
             add (m_col_total_messages);
           }
 
+          Gtk::TreeModelColumn<bool>          m_col_description;
           Gtk::TreeModelColumn<Glib::ustring> m_col_name;
           Gtk::TreeModelColumn<Glib::ustring> m_col_query;
-          Gtk::TreeModelColumn<int>           m_col_unread_messages;
-          Gtk::TreeModelColumn<int>           m_col_total_messages;
+          Gtk::TreeModelColumn<Glib::ustring> m_col_unread_messages;
+          Gtk::TreeModelColumn<Glib::ustring> m_col_total_messages;
 
       };
 

--- a/src/modes/saved_searches.hh
+++ b/src/modes/saved_searches.hh
@@ -17,6 +17,7 @@ namespace Astroid {
       void load_saved_searches ();
       void add_query (ustring, ustring);
 
+      void reload ();
       void refresh_stats ();
 
       static void save_query (ustring query);
@@ -26,6 +27,8 @@ namespace Astroid {
 
       static ptree load_searches ();
       static void write_back_searches (ptree);
+
+      static Glib::Dispatcher m_reload;
 
 
     protected:

--- a/src/modes/saved_searches.hh
+++ b/src/modes/saved_searches.hh
@@ -32,6 +32,8 @@ namespace Astroid {
       void reload ();
       void refresh_stats ();
 
+      int page_jump_rows;
+
     protected:
       class ModelColumns : public Gtk::TreeModel::ColumnRecord
       {

--- a/src/modes/saved_searches.hh
+++ b/src/modes/saved_searches.hh
@@ -13,13 +13,6 @@ namespace Astroid {
       void grab_modal () override;
       void release_modal () override;
 
-      void load_startup_queries ();
-      void load_saved_searches ();
-      void add_query (ustring, ustring, bool saved = false);
-
-      void reload ();
-      void refresh_stats ();
-
       static void save_query (ustring query);
 
     private:
@@ -29,6 +22,12 @@ namespace Astroid {
       static Glib::Dispatcher m_reload;
 
       void on_thread_changed (Db *, ustring);
+      void load_startup_queries ();
+      void load_saved_searches ();
+      void add_query (ustring, ustring, bool saved = false);
+
+      void reload ();
+      void refresh_stats ();
 
     protected:
       class ModelColumns : public Gtk::TreeModel::ColumnRecord

--- a/src/modes/saved_searches.hh
+++ b/src/modes/saved_searches.hh
@@ -1,0 +1,43 @@
+# pragma once
+
+# include "mode.hh"
+
+namespace Astroid {
+  class SavedSearches : public Mode {
+    public:
+      SavedSearches (MainWindow *);
+
+      void grab_modal () override;
+      void release_modal () override;
+
+      void load_startup_queries ();
+      void add_query (ustring, ustring);
+
+    protected:
+      class ModelColumns : public Gtk::TreeModel::ColumnRecord
+      {
+        public:
+
+          ModelColumns()
+          { 
+            add (m_col_name);
+            add (m_col_query);
+            add (m_col_unread_messages);
+            add (m_col_total_messages);
+          }
+
+          Gtk::TreeModelColumn<Glib::ustring> m_col_name;
+          Gtk::TreeModelColumn<Glib::ustring> m_col_query;
+          Gtk::TreeModelColumn<int>           m_col_unread_messages;
+          Gtk::TreeModelColumn<int>           m_col_total_messages;
+
+      };
+
+      ModelColumns m_columns;
+
+      Gtk::TreeView tv;
+      Gtk::ScrolledWindow scroll;
+      refptr<Gtk::ListStore> store;
+  };
+}
+

--- a/src/modes/thread_index/thread_index.cc
+++ b/src/modes/thread_index/thread_index.cc
@@ -15,6 +15,7 @@
 # include "thread_index_list_view.hh"
 # include "thread_index_list_cell_renderer.hh"
 # include "modes/thread_view/thread_view.hh"
+# include "modes/saved_searches.hh"
 # include "main_window.hh"
 
 using namespace std;
@@ -175,6 +176,15 @@ namespace Astroid {
           }
           if (newpath)
             list_view->set_cursor (newpath);
+
+          return true;
+        });
+
+    keys.register_key ("C-S",
+        "thread_index.save_query",
+        "Save query",
+        [&] (Key) {
+          SavedSearches::save_query (query_string);
 
           return true;
         });


### PR DESCRIPTION
#42

Open with `C-f`.

currently only startup queries are shown

The plan is to include:

- [x] saved searches
- [x] update of stats when something happens
- [x] search history is saved, browsable in saved-searches and with Up/Down in search-bar 
- [x] make search history entries savable
- [x] J/K jump several lines
- [x] config for how many histories to show
- [x] possibly keep updated search history list in memory
- [x] make configurable (and default) to show saved searches on startup
- [x] double-click opens query


this is getting pretty close to: https://notmuchmail.org/screenshots/#index1h3