### PR TITLE
add ml to: consideration in account detection

### DIFF
--- a/src/message_thread.hh
+++ b/src/message_thread.hh
@@ -47,6 +47,7 @@ namespace Astroid {
       InternetAddressList * to ();
       InternetAddressList * cc ();
       InternetAddressList * bcc ();
+      InternetAddressList * other_to ();
 
       /* address list with all addresses in all headers beginning with to
        * and ending with from */


### PR DESCRIPTION
improve account detection for ML emails. use other headerfields to detect own address.