### PR TITLE
ti: vary tag color based on md5 hashing

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,22 +1,35 @@
 ==
 
-* Thread-index: load all threads in the background.
-* Synchronize maildir flags if so configured in .notmuch-config.
-* General XEmbed support in editor: Emacs works.
+* Use any editor (general XEmbed support in edit-message window): Emacs works.
+
 * Thread-view: Search email text using '/'
+
+* Synchronize maildir flags if so configured in .notmuch-config.
+
 * Signatures: Include per-account signatures (either included or
   attached).
+
 * Saved searches: Save a search with 'C-S', then browse saved searches
   and stats with 'C-f'. You can also browse search history using Up
   and Down in the search-bar.
+
+* Colorful tags: Tag background color is calculated based on MD5 sum and
+  normalized to within a configurable range. The same tag will therefore
+  always have the same color.
+
+* Thread-index: load all threads in the background.
+
 * All actions requiring write-access run in the background and wait for
   any reads to finish. All read operations need to wait for any ongoing
   write-operations to finish. All write-operations are therefore
   asynchronous and non-blocking. Read-operations will only block on long
   write operations.
+
 * Tags can be modified on multiple marked threads with + and -.
+
 * Modify tags on single message, they are updated in thread-view and
   thread-index.
+
 * scss: fix #82: make all variables global.
 * C-d / C-u / Page in thread-index: Page and move cursor in thread
   index.

--- a/src/astroid.cc
+++ b/src/astroid.cc
@@ -17,6 +17,7 @@
 # include "actions/action_manager.hh"
 # include "actions/action.hh"
 # include "utils/date_utils.hh"
+# include "utils/utils.hh"
 # include "log.hh"
 # include "poll.hh"
 
@@ -214,6 +215,7 @@ namespace Astroid {
 
     /* set up static classes */
     Date::init ();
+    Utils::init ();
     Db::init ();
     Keybindings::init ();
     SavedSearches::init ();
@@ -260,6 +262,7 @@ namespace Astroid {
 
     /* set up static classes */
     Date::init ();
+    Utils::init ();
     Db::init ();
     SavedSearches::init ();
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -159,13 +159,14 @@ namespace Astroid {
     default_config.put ("thread_index.cell.date_length", 10);
     default_config.put ("thread_index.cell.message_count_length", 4);
     default_config.put ("thread_index.cell.authors_length", 20);
-    default_config.put ("thread_index.cell.tags_length", 80);
 
     default_config.put ("thread_index.cell.subject_color", "#807d74");
     default_config.put ("thread_index.cell.subject_color_selected", "#000000");
     default_config.put ("thread_index.cell.background_color_selected", "");
 
-    default_config.put ("thread_index.cell.tags_color", "#31587a");
+    default_config.put ("thread_index.cell.tags_length", 80);
+    default_config.put ("thread_index.cell.tags_blend_color", "#31587a");
+    default_config.put ("thread_index.cell.tags_blend_weight", 0.5);
     default_config.put ("thread_index.cell.hidden_tags", "attachment,flagged,unread");
 
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -165,8 +165,10 @@ namespace Astroid {
     default_config.put ("thread_index.cell.background_color_selected", "");
 
     default_config.put ("thread_index.cell.tags_length", 80);
-    default_config.put ("thread_index.cell.tags_blend_color", "#31587a");
-    default_config.put ("thread_index.cell.tags_blend_weight", 0.5);
+    default_config.put ("thread_index.cell.tags_blend_color", "#ffffff");
+    default_config.put ("thread_index.cell.tags_blend_weight", 1.0);
+    default_config.put ("thread_index.cell.tags_background_color", "#666666");
+    default_config.put ("thread_index.cell.tags_background_color_selected", "#666666");
     default_config.put ("thread_index.cell.hidden_tags", "attachment,flagged,unread");
 
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -165,10 +165,8 @@ namespace Astroid {
     default_config.put ("thread_index.cell.background_color_selected", "");
 
     default_config.put ("thread_index.cell.tags_length", 80);
-    default_config.put ("thread_index.cell.tags_blend_color", "#ffffff");
-    default_config.put ("thread_index.cell.tags_blend_weight", 1.0);
-    default_config.put ("thread_index.cell.tags_background_color", "#666666");
-    default_config.put ("thread_index.cell.tags_background_color_selected", "#666666");
+    default_config.put ("thread_index.cell.tags_upper_color", "#e5e5e5");
+    default_config.put ("thread_index.cell.tags_lower_color", "#333333");
     default_config.put ("thread_index.cell.hidden_tags", "attachment,flagged,unread");
 
 

--- a/src/crypto.cc
+++ b/src/crypto.cc
@@ -86,6 +86,19 @@ namespace Astroid {
   }
 
   ustring Crypto::get_md5_digest (ustring str) {
+    unsigned char * digest = get_md5_digest_char (str);
+
+    std::ostringstream os;
+    for (int i = 0; i < 16; i++) {
+      os << std::hex << std::setfill('0') << std::setw(2) << ((int)digest[i]);
+    }
+
+    delete digest;
+
+    return os.str ();
+  }
+
+  unsigned char * Crypto::get_md5_digest_char (ustring str) {
     GMimeStream * mem = g_mime_stream_mem_new ();
     GMimeStream * filter_stream = g_mime_stream_filter_new (mem);
 
@@ -94,19 +107,15 @@ namespace Astroid {
 
     g_mime_stream_write_string (filter_stream, str.c_str ());
 
-    unsigned char digest[16];
+    unsigned char *digest = new unsigned char[16];
     g_mime_filter_md5_get_digest (GMIME_FILTER_MD5(md5f), digest);
 
-    std::ostringstream os;
-    for (int i = 0; i < 16; i++) {
-      os << std::hex << std::setfill('0') << std::setw(2) << ((int)digest[i]);
-    }
 
     g_object_unref (md5f);
     g_object_unref (filter_stream);
     g_object_unref (mem);
 
-    return os.str ();
+    return digest;
   }
 }
 

--- a/src/crypto.hh
+++ b/src/crypto.hh
@@ -32,6 +32,7 @@ namespace Astroid {
 
     public:
       static ustring get_md5_digest (ustring str);
+      static unsigned char * get_md5_digest_char (ustring str);
   };
 
 }

--- a/src/modes/thread_index/thread_index_list_cell_renderer.cc
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.cc
@@ -335,12 +335,13 @@ namespace Astroid {
 
       unsigned char * tc = Crypto::get_md5_digest_char (t);
 
-      unsigned char upper[3] = { 0xf2, 0xf2, 0xf2 };
+      unsigned char upper[3] = { 0xe5, 0xe5, 0xe5 };
       unsigned char lower[3] = { 0x33, 0x33, 0x33 };
 
       /*
        * normalize the background tag color to be between upper and
-       * lower, then choose font color based on above or below limit
+       * lower, then choose light or dark font color depending on
+       * lightness of background color.
        */
 
       unsigned char bg[3];
@@ -351,7 +352,7 @@ namespace Astroid {
 
       float lum = (bg[0] * .21 + bg[1] * .72 + bg[2] * .07) / 255.0;
       /* float avg = (bg[0] + bg[1] + bg[2]) / (3 * 255.0); */
-      
+
 
       std::ostringstream bg_str;
       bg_str << "#";
@@ -375,11 +376,11 @@ namespace Astroid {
       if (lum > 0.5) {
         fc = "#000000";
       } else {
-        fc = "#ffffff";
+        fc = "#f2f2f2";
       }
 
       tag_string += ustring::compose (
-                  "<span font_style=\"italic\" bgcolor=\"%3\" color=\"%1\"> %2 </span>",
+                  "<span bgcolor=\"%3\" color=\"%1\"> %2 </span>",
                   fc,
                   Glib::Markup::escape_text(t),
                   bg_str.str () );

--- a/src/modes/thread_index/thread_index_list_cell_renderer.cc
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.cc
@@ -54,22 +54,6 @@ namespace Astroid {
     subject_color_selected = ti.get<string> ("subject_color_selected");
     background_color_selected = ti.get<string> ("background_color_selected");
 
-    ustring _tags_upper_color = ti.get<string> ("tags_upper_color");
-    ustring _tags_lower_color = ti.get<string> ("tags_lower_color");
-
-    bool r = false;
-    r = tags_upper_color.parse (_tags_upper_color);
-    if (!r) {
-      log << error << "ti: failed parsing tags_upper_color" << endl;
-      tags_upper_color.parse ("#e5e5e5");
-    }
-
-    r = tags_lower_color.parse (_tags_lower_color);
-    if (!r) {
-      log << error << "ti: failed parsing tags_lower_color" << endl;
-      tags_lower_color.parse ("#e5e5e5");
-    }
-
   }
 
   void ThreadIndexListCellRenderer::render_vfunc (
@@ -349,44 +333,8 @@ namespace Astroid {
       if (len >= tags_len) break;
       broken = false;
 
-      unsigned char * tc = Crypto::get_md5_digest_char (t);
+      auto colors = Utils::get_tag_color (t);
 
-      unsigned char upper[3] = {
-        (unsigned char) tags_upper_color.get_red (),
-        (unsigned char) tags_upper_color.get_green (),
-        (unsigned char) tags_upper_color.get_blue (),
-        };
-
-      unsigned char lower[3] = {
-        (unsigned char) tags_lower_color.get_red (),
-        (unsigned char) tags_lower_color.get_green (),
-        (unsigned char) tags_lower_color.get_blue (),
-        };
-
-      /*
-       * normalize the background tag color to be between upper and
-       * lower, then choose light or dark font color depending on
-       * luminocity of background color.
-       */
-
-      unsigned char bg[3];
-
-      for (int k = 0; k < 3; k++) {
-        bg[k] = tc[k] * (upper[k] - lower[k]) + lower[k];
-      }
-
-      float lum = (bg[0] * .21 + bg[1] * .72 + bg[2] * .07) / 255.0;
-      /* float avg = (bg[0] + bg[1] + bg[2]) / (3 * 255.0); */
-
-      std::ostringstream bg_str;
-      bg_str << "#";
-
-      for (int k = 0; k < 3; k++) {
-        bg_str << std::hex << std::setfill('0') << std::setw(2) << ((int)bg[k]);
-      }
-
-
-      delete tc;
 
       if ((len + t.length () + 2) > static_cast<unsigned int>(tags_len)) {
         t = t.substr (0, (len + t.length () + 2 - tags_len));
@@ -395,18 +343,11 @@ namespace Astroid {
 
       len += t.length () + 2;
 
-      ustring fc;
-      if (lum > 0.5) {
-        fc = "#000000";
-      } else {
-        fc = "#f2f2f2";
-      }
-
       tag_string += ustring::compose (
                   "<span bgcolor=\"%3\" color=\"%1\"> %2 </span>",
-                  fc,
+                  colors.first,
                   Glib::Markup::escape_text(t),
-                  bg_str.str () );
+                  colors.second );
     }
 
     if (broken) {

--- a/src/modes/thread_index/thread_index_list_cell_renderer.cc
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.cc
@@ -54,7 +54,8 @@ namespace Astroid {
     subject_color_selected = ti.get<string> ("subject_color_selected");
     background_color_selected = ti.get<string> ("background_color_selected");
 
-    tags_color    = ti.get<string> ("tags_color");
+    tags_blend_color = ti.get<string> ("tags_blend_color");
+    tags_blend_weight = ti.get<double> ("tags_blend_weight");
 
   }
 
@@ -330,14 +331,23 @@ namespace Astroid {
 
       unsigned char * tc = Crypto::get_md5_digest_char (t);
 
-      /* blend color: 31587a*/
+      /* blend color: default 31587a*/
       unsigned char base[3] = { 0x31, 0x58, 0x7a };
+
+      Pango::Color pbase;
+      bool r = pbase.parse (tags_blend_color);
+      if (!r) {
+        log << error << "til cr: failed parsing blend color: " << tags_blend_color << endl;
+      } else {
+        base[0] = pbase.get_red ();
+        base[1] = pbase.get_green ();
+        base[2] = pbase.get_blue ();
+      }
+
       unsigned char blend[3];
 
-      double blend_weight = 2.0;
-
       for (int k = 0; k < 3; k++) {
-        blend[k] = (base[k] * blend_weight + tc[(16 - 3 + k)]) / (blend_weight + 1);
+        blend[k] = (base[k] + tc[(16 - 3 + k)] * tags_blend_weight) / (tags_blend_weight + 1);
       }
 
       std::ostringstream tc_str;

--- a/src/modes/thread_index/thread_index_list_cell_renderer.cc
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.cc
@@ -335,6 +335,7 @@ namespace Astroid {
 
     ustring tag_string = "";
     bool first = true;
+    bool broken = false;
     int len = 0;
 
     for (auto t : tags) {
@@ -344,7 +345,9 @@ namespace Astroid {
       }
       first = false;
 
+      broken = true;
       if (len >= tags_len) break;
+      broken = false;
 
       unsigned char * tc = Crypto::get_md5_digest_char (t);
 
@@ -385,8 +388,9 @@ namespace Astroid {
 
       delete tc;
 
-      if (len + t.length () > static_cast<unsigned int>(tags_len)) {
+      if ((len + t.length () + 2) > static_cast<unsigned int>(tags_len)) {
         t = t.substr (0, (len + t.length () + 2 - tags_len));
+        t += "..";
       }
 
       len += t.length () + 2;
@@ -403,6 +407,10 @@ namespace Astroid {
                   fc,
                   Glib::Markup::escape_text(t),
                   bg_str.str () );
+    }
+
+    if (broken) {
+      tag_string += "..";
     }
 
     pango_layout->set_markup (tag_string);

--- a/src/modes/thread_index/thread_index_list_cell_renderer.cc
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.cc
@@ -337,7 +337,6 @@ namespace Astroid {
 
       unsigned char upper[3] = { 0xf2, 0xf2, 0xf2 };
       unsigned char lower[3] = { 0x33, 0x33, 0x33 };
-      unsigned char limit[3] = { 0x88, 0x88, 0x88 };
 
       /*
        * normalize the background tag color to be between upper and
@@ -345,13 +344,14 @@ namespace Astroid {
        */
 
       unsigned char bg[3];
-      bool above = false;
 
       for (int k = 0; k < 3; k++) {
         bg[k] = tc[k] * (upper[k] - lower[k]) + lower[k];
-        if (bg[2-k] >= limit[2-k]) above = true;
-        else above = false;
       }
+
+      float lum = (bg[0] * .21 + bg[1] * .72 + bg[2] * .07) / 255.0;
+      /* float avg = (bg[0] + bg[1] + bg[2]) / (3 * 255.0); */
+      
 
       std::ostringstream bg_str;
       bg_str << "#";
@@ -372,10 +372,10 @@ namespace Astroid {
 
       /* TODO: get length of extra spacing and , into len */
       ustring fc;
-      if (!above) {
-        fc = "#ffffff";
-      } else {
+      if (lum > 0.5) {
         fc = "#000000";
+      } else {
+        fc = "#ffffff";
       }
 
       tag_string += ustring::compose (

--- a/src/modes/thread_index/thread_index_list_cell_renderer.cc
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.cc
@@ -325,7 +325,7 @@ namespace Astroid {
 
     for (auto t : tags) {
       if (!first) {
-        tag_string += ",";
+        tag_string += " ";
         len++;
       }
       first = false;

--- a/src/modes/thread_index/thread_index_list_cell_renderer.cc
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.cc
@@ -318,42 +318,7 @@ namespace Astroid {
                     hidden_tags.end (),
                     back_inserter(tags));
 
-    ustring tag_string = "";
-    bool first = true;
-    bool broken = false;
-    int len = 0;
-
-    for (auto t : tags) {
-      if (!first) {
-        tag_string += " ";
-        len++;
-      }
-      first = false;
-
-      broken = true;
-      if (len >= tags_len) break;
-      broken = false;
-
-      auto colors = Utils::get_tag_color (t);
-
-
-      if ((len + t.length () + 2) > static_cast<unsigned int>(tags_len)) {
-        t = t.substr (0, (len + t.length () + 2 - tags_len));
-        t += "..";
-      }
-
-      len += t.length () + 2;
-
-      tag_string += ustring::compose (
-                  "<span bgcolor=\"%3\" color=\"%1\"> %2 </span>",
-                  colors.first,
-                  Glib::Markup::escape_text(t),
-                  colors.second );
-    }
-
-    if (broken) {
-      tag_string += "..";
-    }
+    ustring tag_string = VectorUtils::concat_tags_color (tags, true, tags_len);
 
     pango_layout->set_markup (tag_string);
 

--- a/src/modes/thread_index/thread_index_list_cell_renderer.cc
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.cc
@@ -73,6 +73,7 @@ namespace Astroid {
       padding = char_width;
 
       content_height  = calculate_height (widget);
+      line_height     = content_height + line_spacing;
       height_set = true;
 
       left_icons_size  = content_height - (2 * left_icons_padding);
@@ -171,14 +172,14 @@ namespace Astroid {
       Glib::RefPtr<Gdk::Pixbuf> pixbuf = theme->load_icon (
           "object-select-symbolic",
           left_icons_size,
-          Gtk::ICON_LOOKUP_USE_BUILTIN );
+          Gtk::ICON_LOOKUP_USE_BUILTIN  | Gtk::ICON_LOOKUP_FORCE_SIZE);
 
 
       marked_icon = pixbuf->scale_simple (left_icons_size, left_icons_size,
           Gdk::INTERP_BILINEAR);
     }
 
-    int y = cell_area.get_y() + left_icons_padding;
+    int y = cell_area.get_y() + left_icons_padding + line_spacing / 2;
     int x = cell_area.get_x();
 
     Gdk::Cairo::set_source_pixbuf (cr, marked_icon, x, y);
@@ -198,13 +199,13 @@ namespace Astroid {
       Glib::RefPtr<Gdk::Pixbuf> pixbuf = theme->load_icon (
           "starred-symbolic",
           left_icons_size,
-          Gtk::ICON_LOOKUP_USE_BUILTIN );
+          Gtk::ICON_LOOKUP_USE_BUILTIN  | Gtk::ICON_LOOKUP_FORCE_SIZE);
 
       flagged_icon = pixbuf->scale_simple (left_icons_size, left_icons_size,
           Gdk::INTERP_BILINEAR);
     }
 
-    int y = cell_area.get_y() + left_icons_padding;
+    int y = cell_area.get_y() + left_icons_padding + line_spacing / 2;
     int x = cell_area.get_x() + left_icons_width + left_icons_padding;
 
     Gdk::Cairo::set_source_pixbuf (cr, flagged_icon, x, y);
@@ -225,14 +226,14 @@ namespace Astroid {
       Glib::RefPtr<Gdk::Pixbuf> pixbuf = theme->load_icon (
           "mail-attachment-symbolic",
           left_icons_size,
-          Gtk::ICON_LOOKUP_USE_BUILTIN );
+          Gtk::ICON_LOOKUP_USE_BUILTIN | Gtk::ICON_LOOKUP_FORCE_SIZE);
 
 
       attachment_icon = pixbuf->scale_simple (left_icons_size, left_icons_size,
           Gdk::INTERP_BILINEAR);
     }
 
-    int y = cell_area.get_y() + left_icons_padding;
+    int y = cell_area.get_y() + left_icons_padding + line_spacing / 2;
     int x = cell_area.get_x() + (2 * (left_icons_width + left_icons_padding));
 
     Gdk::Cairo::set_source_pixbuf (cr, attachment_icon, x, y);
@@ -286,7 +287,7 @@ namespace Astroid {
     /* align in the middle */
     int w, h;
     pango_layout->get_size (w, h);
-    int y = max(0,(content_height / 2) - ((h / Pango::SCALE) / 2));
+    int y = max(0,(line_height / 2) - ((h / Pango::SCALE) / 2));
 
     cr->move_to (cell_area.get_x() + subject_start, cell_area.get_y() + y);
     pango_layout->show_in_cairo_context (cr);
@@ -359,7 +360,7 @@ namespace Astroid {
     /* align in the middle */
     int w, h;
     pango_layout->get_size (w, h);
-    int y = max(0,(content_height / 2) - ((h / Pango::SCALE) / 2));
+    int y = max(0,(line_height / 2) - ((h / Pango::SCALE) / 2));
 
     cr->move_to (cell_area.get_x() + tags_start, cell_area.get_y() + y);
     pango_layout->show_in_cairo_context (cr);
@@ -387,7 +388,7 @@ namespace Astroid {
     /* align in the middle */
     int w, h;
     pango_layout->get_size (w, h);
-    int y = max(0,(content_height / 2) - ((h / Pango::SCALE) / 2));
+    int y = max(0,(line_height / 2) - ((h / Pango::SCALE) / 2));
 
     /* update subject start */
     //subject_start = date_start + (w / Pango::SCALE) + padding;
@@ -421,7 +422,7 @@ namespace Astroid {
     /* align in the middle */
     int w, h;
     pango_layout->get_size (w, h);
-    int y = max(0,(content_height / 2) - ((h / Pango::SCALE) / 2));
+    int y = max(0,(line_height / 2) - ((h / Pango::SCALE) / 2));
 
     /* update subject start */
     //subject_start = date_start + (w / Pango::SCALE) + padding;
@@ -519,7 +520,7 @@ namespace Astroid {
     /* align in the middle */
     int w, h;
     pango_layout->get_size (w, h);
-    int y = max(0,(content_height / 2) - ((h / Pango::SCALE) / 2));
+    int y = max(0,(line_height / 2) - ((h / Pango::SCALE) / 2));
 
     /* update subject start */
     //subject_start = date_start + (w / Pango::SCALE) + padding;
@@ -531,7 +532,7 @@ namespace Astroid {
 
   /* cellrenderer overloads {{{ */
   int ThreadIndexListCellRenderer::get_height () {
-    if (height_set) return (content_height + line_spacing);
+    if (height_set) return line_height;
     else return 0;
   }
 

--- a/src/modes/thread_index/thread_index_list_cell_renderer.cc
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.cc
@@ -326,6 +326,8 @@ namespace Astroid {
       if (!first) tag_string += ", ";
       first = false;
 
+      if (len >= tags_len) break;
+
       unsigned char * tc = Crypto::get_md5_digest_char (t);
 
       /* blend color: 31587a*/
@@ -350,6 +352,8 @@ namespace Astroid {
       if (len + t.length () > static_cast<unsigned int>(tags_len)) {
         t = t.substr (0, (len + t.length () - tags_len));
       }
+
+      len += t.length ();
 
 
       tag_string += ustring::compose (

--- a/src/modes/thread_index/thread_index_list_cell_renderer.hh
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.hh
@@ -95,8 +95,10 @@ namespace Astroid {
       int tags_start;
       int tags_width;
       int tags_len = 80; // chars, configurable
-      ustring tags_blend_color; // configurable, default: 31587a
-      double  tags_blend_weight; // configurable, default: 0.5
+      ustring tags_blend_color; // configurable
+      ustring tags_background_color;
+      ustring tags_background_color_selected;
+      double  tags_blend_weight; // configurable
 
       int subject_start;
       ustring subject_color; // configurable
@@ -118,7 +120,8 @@ namespace Astroid {
       int render_tags (
           const ::Cairo::RefPtr< ::Cairo::Context>&cr,
           Gtk::Widget &widget,
-          const Gdk::Rectangle &cell_area );
+          const Gdk::Rectangle &cell_area,
+          Gtk::CellRendererState flags );
 
       int render_date (
           const ::Cairo::RefPtr< ::Cairo::Context>&cr,

--- a/src/modes/thread_index/thread_index_list_cell_renderer.hh
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.hh
@@ -95,10 +95,8 @@ namespace Astroid {
       int tags_start;
       int tags_width;
       int tags_len = 80; // chars, configurable
-      ustring tags_blend_color; // configurable
-      ustring tags_background_color;
-      ustring tags_background_color_selected;
-      double  tags_blend_weight; // configurable
+      Pango::Color tags_upper_color;
+      Pango::Color tags_lower_color;
 
       int subject_start;
       ustring subject_color; // configurable

--- a/src/modes/thread_index/thread_index_list_cell_renderer.hh
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.hh
@@ -95,7 +95,8 @@ namespace Astroid {
       int tags_start;
       int tags_width;
       int tags_len = 80; // chars, configurable
-      ustring tags_color; // configurable
+      ustring tags_blend_color; // configurable, default: 31587a
+      double  tags_blend_weight; // configurable, default: 0.5
 
       int subject_start;
       ustring subject_color; // configurable

--- a/src/modes/thread_index/thread_index_list_cell_renderer.hh
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.hh
@@ -67,6 +67,7 @@ namespace Astroid {
       bool height_set = false;
 
     private:
+      int line_height; // content_height + line_spacing
       int content_height;
       int line_spacing = 2; // configurable
 

--- a/src/modes/thread_index/thread_index_list_cell_renderer.hh
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.hh
@@ -95,8 +95,6 @@ namespace Astroid {
       int tags_start;
       int tags_width;
       int tags_len = 80; // chars, configurable
-      Pango::Color tags_upper_color;
-      Pango::Color tags_lower_color;
 
       int subject_start;
       ustring subject_color; // configurable

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -640,11 +640,7 @@ namespace Astroid {
 
     if (!wk_loaded || !ready) return;
 
-    ustring tags_s = VectorUtils::concat_tags (m->tags);
-
-    ustring tags_s_c = ustring::compose ("<span style=\"color:#31587a !important\">%1</span>",
-        header_row_value (tags_s, true));
-
+    ustring tags_s = VectorUtils::concat_tags_color (m->tags);
     GError *err;
     ustring mid = "message_" + m->mid;
 
@@ -656,7 +652,7 @@ namespace Astroid {
         WEBKIT_DOM_NODE (div_message),
         ".header_container .tags");
 
-    webkit_dom_html_element_set_inner_html (tags, header_row_value(tags_s, true).c_str(), (err = NULL, &err));
+    webkit_dom_html_element_set_inner_html (tags, tags_s.c_str (), (err = NULL, &err));
 
     g_object_unref (tags);
 
@@ -664,7 +660,7 @@ namespace Astroid {
         WEBKIT_DOM_NODE (div_message),
         ".header_container .header div#Tags .value");
 
-    webkit_dom_html_element_set_inner_html (tags, tags_s_c.c_str (), (err = NULL, &err));
+    webkit_dom_html_element_set_inner_html (tags, tags_s.c_str (), (err = NULL, &err));
 
     g_object_unref (tags);
     g_object_unref (div_message);
@@ -895,19 +891,17 @@ namespace Astroid {
     }
 
     if (m->in_notmuch) {
-      ustring tags_s = VectorUtils::concat_tags (m->tags);
+      ustring tags_s = VectorUtils::concat_tags_color (m->tags);
 
-      ustring tags_s_c = ustring::compose ("<span style=\"color:#31587a !important\">%1</span>",
-          Glib::Markup::escape_text(tags_s));
 
-      header += create_header_row ("Tags", tags_s_c, false, false, true);
+      header += create_header_row ("Tags", tags_s, false, false, true);
 
 
       WebKitDOMHTMLElement * tags = DomUtils::select (
           WEBKIT_DOM_NODE (div_message),
           ".header_container .tags");
 
-      webkit_dom_html_element_set_inner_html (tags, Glib::Markup::escape_text(tags_s).c_str(), (err = NULL, &err));
+      webkit_dom_html_element_set_inner_html (tags,tags_s.c_str(), (err = NULL, &err));
 
       g_object_unref (tags);
     }

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -640,7 +640,7 @@ namespace Astroid {
 
     if (!wk_loaded || !ready) return;
 
-    ustring tags_s = VectorUtils::concat_tags_color (m->tags);
+    ustring tags_s = VectorUtils::concat_tags_color (m->tags, false, 0);
     GError *err;
     ustring mid = "message_" + m->mid;
 
@@ -891,7 +891,7 @@ namespace Astroid {
     }
 
     if (m->in_notmuch) {
-      ustring tags_s = VectorUtils::concat_tags_color (m->tags);
+      ustring tags_s = VectorUtils::concat_tags_color (m->tags, false, 0);
 
 
       header += create_header_row ("Tags", tags_s, false, false, true);

--- a/src/utils/utils.hh
+++ b/src/utils/utils.hh
@@ -9,11 +9,18 @@ namespace Astroid {
   class Utils {
     public:
 
+      static void init ();
+
       /* return human readable file size */
       static ustring format_size (int sz);
 
       /* make filename safe */
       static ustring safe_fname (ustring fname);
+
+      /* get tag color */
+      static std::pair<ustring, ustring> get_tag_color (ustring);
+      static Pango::Color tags_upper_color;
+      static Pango::Color tags_lower_color;
 
   };
 }

--- a/src/utils/vector_utils.cc
+++ b/src/utils/vector_utils.cc
@@ -58,23 +58,54 @@ namespace Astroid {
     return concat (tags, ", ", stop_ons_tags);
   }
 
-  ustring VectorUtils::concat_tags_color (vector<ustring> tags) {
+  ustring VectorUtils::concat_tags_color (
+      vector<ustring> tags,
+      bool pango,
+      int maxlen ) {
+
     ustring tag_string = "";
     bool first = true;
+    bool broken = false;
+    int len = 0;
 
     for (auto t : tags) {
+
       if (!first) {
         tag_string += " ";
+      } else first = false;
+
+      if (maxlen > 0) {
+        broken = true;
+        if (len >= maxlen) break;
+        broken = false;
+
+        if ((len + t.length () + 2) > static_cast<unsigned int>(maxlen)) {
+          t = t.substr (0, (len + t.length () + 2 - maxlen));
+          t += "..";
+        }
+
+        len += t.length () + 2;
       }
-      first = false;
 
       auto colors = Utils::get_tag_color (t);
+      if (pango) {
+        tag_string += ustring::compose (
+                    "<span bgcolor=\"%3\" color=\"%1\"> %2 </span>",
+                    colors.first,
+                    Glib::Markup::escape_text(t),
+                    colors.second );
 
-      tag_string += ustring::compose (
-                  "<span style=\"background-color: %3; color: %1 !important; white-space: pre;\"> %2 </span>",
-                  colors.first,
-                  Glib::Markup::escape_text(t),
-                  colors.second );
+      } else {
+        tag_string += ustring::compose (
+                    "<span style=\"background-color: %3; color: %1 !important; white-space: pre;\"> %2 </span>",
+                    colors.first,
+                    Glib::Markup::escape_text(t),
+                    colors.second );
+      }
+    }
+
+    if (broken) {
+      tag_string += "..";
     }
 
 

--- a/src/utils/vector_utils.cc
+++ b/src/utils/vector_utils.cc
@@ -64,7 +64,7 @@ namespace Astroid {
 
     for (auto t : tags) {
       if (!first) {
-        tag_string += ",";
+        tag_string += " ";
       }
       first = false;
 

--- a/src/utils/vector_utils.cc
+++ b/src/utils/vector_utils.cc
@@ -4,6 +4,7 @@
 # include "astroid.hh"
 # include "vector_utils.hh"
 # include "ustring_utils.hh"
+# include "utils.hh"
 
 using namespace std;
 
@@ -55,6 +56,29 @@ namespace Astroid {
 
   ustring VectorUtils::concat_tags (vector<ustring> tags) {
     return concat (tags, ", ", stop_ons_tags);
+  }
+
+  ustring VectorUtils::concat_tags_color (vector<ustring> tags) {
+    ustring tag_string = "";
+    bool first = true;
+
+    for (auto t : tags) {
+      if (!first) {
+        tag_string += ",";
+      }
+      first = false;
+
+      auto colors = Utils::get_tag_color (t);
+
+      tag_string += ustring::compose (
+                  "<span style=\"background-color: %3; color: %1 !important; white-space: pre;\"> %2 </span>",
+                  colors.first,
+                  Glib::Markup::escape_text(t),
+                  colors.second );
+    }
+
+
+    return tag_string;
   }
 }
 

--- a/src/utils/vector_utils.hh
+++ b/src/utils/vector_utils.hh
@@ -14,7 +14,7 @@ namespace Astroid {
       static std::vector<ustring> split_and_trim (const ustring & str, const ustring delim);
       static ustring concat (std::vector<ustring> &, ustring, std::vector<ustring>);
       static ustring concat_tags (std::vector<ustring>);
-      static ustring concat_tags_color (std::vector<ustring>);
+      static ustring concat_tags_color (std::vector<ustring>, bool pango, int maxlen = 0);
 
       static const std::vector<ustring> stop_ons_tags;
 

--- a/src/utils/vector_utils.hh
+++ b/src/utils/vector_utils.hh
@@ -14,6 +14,7 @@ namespace Astroid {
       static std::vector<ustring> split_and_trim (const ustring & str, const ustring delim);
       static ustring concat (std::vector<ustring> &, ustring, std::vector<ustring>);
       static ustring concat_tags (std::vector<ustring>);
+      static ustring concat_tags_color (std::vector<ustring>);
 
       static const std::vector<ustring> stop_ons_tags;
 


### PR DESCRIPTION
each tag is assigned a color based on the last 6 digits in the md5 sum
of the tag. the color is blended with a base color weighting the base
color with a coefficient of 0.5 to have colors oscilliate around the
base.

each tag will therefore always have the same color, since the last
digits are used it is unlikely that similar tags (and adjacent in the
listing) will have the same color.

the base color is configurable, the same is the weight. by setting the weight to 0 only the base color is used.

#139