### PR TITLE
Thread view search

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -27,6 +27,9 @@
 * Gravatar is configurable.
 * #103: Drafts are saved on force close or quit by default.
 * C-v: duplicate and refine query.
+* Mark thread moves to next by default.
+* ti: set cursor to first thread if we are at first thread when new
+  addition is made.
 
 == v0.5 / 2016-02-06
 

--- a/History.txt
+++ b/History.txt
@@ -3,6 +3,7 @@
 * Thread-index: load all threads in the background.
 * Synchronize maildir flags if so configured in .notmuch-config.
 * General XEmbed support in editor: Emacs works.
+* Thread-view: Search email text using '/'
 * Signatures: Include per-account signatures (either included or
   attached).
 * Saved searches: Save a search with 'C-S', then browse saved searches

--- a/src/command_bar.hh
+++ b/src/command_bar.hh
@@ -22,6 +22,7 @@ namespace Astroid {
     public:
       enum CommandMode {
         Search = 0,
+        SearchText,
         //Generic,
         Tag,        /* apply or remove tags */
         DiffTag,    /* apply or remove tags using + or - */
@@ -192,5 +193,36 @@ namespace Astroid {
       };
 
       refptr<SearchCompletion> search_completion;
+
+      /********************
+       * SearchText completion
+       ********************/
+      void start_text_searching (ustring);
+
+      class SearchTextCompletion : public GenericCompletion {
+        public:
+          SearchTextCompletion ();
+
+          /* the search text completion maintains only the queries that have
+           * been done during this program execution, the state is not saved */
+
+          // tree model columns, for the EntryCompletion's filter model
+          class ModelColumns : public Gtk::TreeModel::ColumnRecord
+          {
+            public:
+
+              ModelColumns ()
+              { add(m_query); }
+
+              Gtk::TreeModelColumn<Glib::ustring> m_query;
+          };
+
+          ModelColumns m_columns;
+
+          void add_query (ustring);
+          bool on_match_selected(const Gtk::TreeModel::iterator& iter) override;
+      };
+
+      refptr<SearchTextCompletion> text_search_completion;
   };
 }

--- a/src/modes/thread_index/query_loader.cc
+++ b/src/modes/thread_index/query_loader.cc
@@ -298,6 +298,13 @@ namespace Astroid {
       log << debug << "ql: updated: did not find thread, time used: " << ((clock() - t0) * 1000.0 / CLOCKS_PER_SEC) << " ms." << endl;
       if (in_query) {
         log << debug << "ql: new thread for query, adding.." << endl;
+
+        /* get current cursor path, if we are at first row and the new addition
+         * is before we should scroll up. */
+        Gtk::TreePath path;
+        Gtk::TreeViewColumn *c;
+        list_view->get_cursor (path, c);
+
         auto iter = list_store->prepend ();
         Gtk::ListStore::Row newrow = *iter;
 
@@ -318,6 +325,14 @@ namespace Astroid {
         if (list_store->children().size() == 1) {
           if (!in_destructor)
             first_thread_ready.emit ();
+        } else {
+
+          if (path == Gtk::TreePath ("0")) {
+            Gtk::TreePath addpath = list_store->get_path (iter);
+            if (addpath <= path) {
+              list_view->set_cursor (addpath);
+            }
+          }
         }
       }
     }

--- a/src/modes/thread_index/query_loader.hh
+++ b/src/modes/thread_index/query_loader.hh
@@ -30,6 +30,7 @@ namespace Astroid {
       void refresh_stats (Db *);
 
       refptr<ThreadIndexListStore> list_store;
+      ThreadIndexListView * list_view;
 
       notmuch_sort_t sort;
       std::vector<ustring> sort_strings = { "oldest", "newest", "messageid", "unsorted" };

--- a/src/modes/thread_index/thread_index.cc
+++ b/src/modes/thread_index/thread_index.cc
@@ -32,6 +32,8 @@ namespace Astroid {
     queryloader.list_store = list_store;
 
     list_view  = Gtk::manage(new ThreadIndexListView (this, list_store));
+    queryloader.list_view = list_view;
+
     scroll     = Gtk::manage(new ThreadIndexScrolled (main_window, list_store, list_view));
 
     list_view->set_sort_type (queryloader.sort);

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -679,8 +679,8 @@ namespace Astroid {
           return true;
         });
 
-    keys->register_key ("t", "thread_index.toggle_marked",
-        "Mark thread",
+    keys->register_key ("t", "thread_index.toggle_marked_next",
+        "Toggle mark thread and move to next",
         [&] (Key) {
           if (list_store->children().size() < 1)
             return true;
@@ -695,6 +695,59 @@ namespace Astroid {
           if (iter) {
             Gtk::ListStore::Row row = *iter;
             row[list_store->columns.marked] = !row[list_store->columns.marked];
+
+            /* move to next thread */
+            path.next ();
+            iter = list_store->get_iter (path);
+            if (iter) set_cursor (path);
+          }
+
+          return true;
+        });
+
+    keys->register_key (UnboundKey (), "thread_index.toggle_marked",
+        "Toggle mark thread",
+        [&] (Key) {
+          if (list_store->children().size() < 1)
+            return true;
+
+          Gtk::TreePath path;
+          Gtk::TreeViewColumn *c;
+          get_cursor (path, c);
+          Gtk::TreeIter iter;
+
+          iter = list_store->get_iter (path);
+
+          if (iter) {
+            Gtk::ListStore::Row row = *iter;
+            row[list_store->columns.marked] = !row[list_store->columns.marked];
+          }
+
+          return true;
+        });
+
+    keys->register_key (UnboundKey (), "thread_index.toggle_marked_previous",
+        "Toggle mark thread and move to previous",
+        [&] (Key) {
+          if (list_store->children().size() < 1)
+            return true;
+
+          Gtk::TreePath path;
+          Gtk::TreeViewColumn *c;
+          get_cursor (path, c);
+          Gtk::TreeIter iter;
+
+          iter = list_store->get_iter (path);
+
+          if (iter) {
+            Gtk::ListStore::Row row = *iter;
+            row[list_store->columns.marked] = !row[list_store->columns.marked];
+
+            /* move to previous */
+            path.prev ();
+            if (path) {
+              set_cursor (path);
+            }
           }
 
           return true;

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -2475,6 +2475,18 @@ namespace Astroid {
           return true;
         });
 
+    keys.register_key (",", "thread_view.search",
+        "Search for text",
+        sigc::mem_fun (this, &ThreadView::search));
+
+
+    keys.register_key (GDK_KEY_Escape, "thread_view.search_cancel",
+        "Cancel current search",
+        [&] (Key) {
+          reset_search ();
+          return true;
+        });
+
   }
 
   // }}}
@@ -3335,5 +3347,47 @@ namespace Astroid {
   }
 
   /* end MessageState }}} */
+
+  /* Searching {{{ */
+  bool ThreadView::search (Key) {
+    reset_search ();
+
+    main_window->enable_command (CommandBar::CommandMode::SearchText,
+        "", sigc::mem_fun (this, &ThreadView::on_search));
+
+    return true;
+  }
+
+  void ThreadView::reset_search () {
+    /* reset */
+    in_search = false;
+    webkit_web_view_set_highlight_text_matches (webview, false);
+    webkit_web_view_unmark_text_matches (webview);
+  }
+
+  void ThreadView::on_search (ustring k) {
+    reset_search ();
+
+    if (!k.empty ()) {
+      log << debug << "tv: searching for: " << k << endl;
+      int n = webkit_web_view_mark_text_matches (webview, k.c_str (), false, 0);
+      if (n > 0) webkit_web_view_set_highlight_text_matches (webview, true);
+
+      log << debug << "tv: search, found: " << n << " matches." << endl;
+
+      in_search = (n > 0);
+    }
+  }
+
+  void ThreadView::next_search_match () {
+    if (!in_search) return;
+  }
+
+  void ThreadView::prev_search_match () {
+    if (!in_search) return;
+
+  }
+
+  /* }}} */
 }
 

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -2475,15 +2475,29 @@ namespace Astroid {
           return true;
         });
 
-    keys.register_key (",", "thread_view.search",
+    keys.register_key ("/", "thread_view.search.search",
         "Search for text",
         sigc::mem_fun (this, &ThreadView::search));
 
 
-    keys.register_key (GDK_KEY_Escape, "thread_view.search_cancel",
+    keys.register_key (GDK_KEY_Escape, "thread_view.search.cancel",
         "Cancel current search",
         [&] (Key) {
           reset_search ();
+          return true;
+        });
+
+    keys.register_key ("N", "thread_view.search.next",
+        "Go to next match",
+        [&] (Key) {
+          next_search_match ();
+          return true;
+        });
+
+    keys.register_key ("P", "thread_view.search.previous",
+        "Go to previous match",
+        [&] (Key) {
+          prev_search_match ();
           return true;
         });
 
@@ -2638,6 +2652,57 @@ namespace Astroid {
         }
       }
     }
+
+    if (in_search && in_search_match) {
+      /* focus message in vertical center */
+
+      update_focus_to_center ();
+
+      in_search_match = false;
+    }
+  }
+
+  void ThreadView::update_focus_to_center () {
+    /* focus the message which is currently vertically centered */
+
+    if (edit_mode) return;
+
+    WebKitDOMDocument * d = webkit_web_view_get_dom_document (webview);
+
+    auto adj = scroll.get_vadjustment ();
+    double scrolled = adj->get_value ();
+    double height   = adj->get_page_size (); // 0 when there is
+
+    if (height == 0) height = scroll.get_height ();
+
+    double center = scrolled + (height / 2);
+
+    for (auto &m : mthread->messages) {
+      ustring mid = "message_" + m->mid;
+
+      WebKitDOMElement * e = webkit_dom_document_get_element_by_id (d, mid.c_str());
+
+      double clientY = webkit_dom_element_get_offset_top (e);
+      double clientH = webkit_dom_element_get_client_height (e);
+
+      // log << debug << "y = " << clientY << endl;
+      // log << debug << "h = " << clientH << endl;
+
+      g_object_unref (e);
+
+      if ((clientY < center) && ((clientY + clientH) > center))
+      {
+        // log << debug << "message: " << m->date() << " now in view." << endl;
+
+        focused_message = m;
+
+        break;
+      }
+    }
+
+    g_object_unref (d);
+
+    update_focus_status ();
   }
 
   void ThreadView::update_focus_to_view () {
@@ -3360,7 +3425,16 @@ namespace Astroid {
 
   void ThreadView::reset_search () {
     /* reset */
+    if (in_search) {
+      /* reset search expanded state */
+      for (auto m : mthread->messages) {
+        state[m].search_expanded = false;
+      }
+    }
+
     in_search = false;
+    in_search_match = false;
+    search_q  = "";
     webkit_web_view_set_highlight_text_matches (webview, false);
     webkit_web_view_unmark_text_matches (webview);
   }
@@ -3369,23 +3443,58 @@ namespace Astroid {
     reset_search ();
 
     if (!k.empty ()) {
+
+      /* expand all messages, these should be closed - except the focused one
+       * when a search is cancelled */
+      for (auto m : mthread->messages) {
+        state[m].search_expanded = is_hidden (m);
+        toggle_hidden (m, ToggleShow);
+      }
+
       log << debug << "tv: searching for: " << k << endl;
       int n = webkit_web_view_mark_text_matches (webview, k.c_str (), false, 0);
-      if (n > 0) webkit_web_view_set_highlight_text_matches (webview, true);
 
       log << debug << "tv: search, found: " << n << " matches." << endl;
 
       in_search = (n > 0);
+
+      if (in_search) {
+        search_q = k;
+
+        webkit_web_view_set_highlight_text_matches (webview, true);
+
+        next_search_match ();
+
+      } else {
+        /* un-expand messages again */
+        for (auto m : mthread->messages) {
+          if (state[m].search_expanded) toggle_hidden (m, ToggleHide);
+          state[m].search_expanded = false;
+        }
+
+      }
     }
   }
 
   void ThreadView::next_search_match () {
     if (!in_search) return;
+    /* there does not seem to be a way to figure out which message currently
+     * contains the selected matched text, but when there is a scroll event
+     * the match is centered.
+     *
+     * the focusing is handled in on_scroll_vadjustment...
+     *
+     */
+
+    in_search_match = true;
+    webkit_web_view_search_text (webview, search_q.c_str (), false, true, true);
   }
 
   void ThreadView::prev_search_match () {
     if (!in_search) return;
 
+    in_search_match = true;
+    webkit_web_view_search_text (webview, search_q.c_str (), false, false, true);
   }
 
   /* }}} */

--- a/src/modes/thread_view/thread_view.hh
+++ b/src/modes/thread_view/thread_view.hh
@@ -93,6 +93,7 @@ namespace Astroid {
       bool    _scroll_when_visible;
 
       void update_focus_to_view ();
+      void update_focus_to_center ();
       void update_focus_status ();
       ustring focus_next ();
       ustring focus_previous (bool focus_top = false);
@@ -116,6 +117,7 @@ namespace Astroid {
 
           /* the message was expanded as part of an
            * C-n or C-p command */
+          bool search_expanded  = false;
           bool scroll_expanded  = false;
           bool print_expanded   = false;
           bool marked           = false;
@@ -282,6 +284,8 @@ namespace Astroid {
       void prev_search_match ();
 
       bool in_search = false;
+      bool in_search_match = false;
+      ustring search_q = "";
 
     public:
       /* the tv is ready */

--- a/src/modes/thread_view/thread_view.hh
+++ b/src/modes/thread_view/thread_view.hh
@@ -273,6 +273,16 @@ namespace Astroid {
       void on_message_changed (Db *, Message *, Message::MessageChangedEvent);
       void on_thread_updated (Db *, ustring);
 
+      /* search */
+      bool search (Key);
+      void on_search (ustring);
+      void reset_search ();
+
+      void next_search_match ();
+      void prev_search_match ();
+
+      bool in_search = false;
+
     public:
       /* the tv is ready */
       typedef sigc::signal <void> type_signal_ready;


### PR DESCRIPTION
Search in thread view using `/`.

You can search for text-strings in thread-view using `/` (I opted to not shadow `F`, but you can re-configure this yourself). Then browse the search-results with `N` and `P` (currently shadowing manual poll from thread-view). Stop searching and drop highlighting using `Escape`.

Focusing is a bit of a problem as there does not seem to be a way to get the position of the currently selected text (or the actual text without going through the clipboard). But whenever webkit scrolls the view to a new result it centers it, so when there is a scroll event during searching I focus the centered message, otherwise focus might be a bit off.

When searching all messages are expanded, otherwise hidden matches may be found when iterating over the results.

#141.